### PR TITLE
Merge Tracer.join_trace into Tracer.start_trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,9 @@ Somewhere in your server's request handler code:
             trace_attributes=request.headers
         )
         operation = request.operation
-        if context is None:
-            span = tracer.start_trace(operation_name=operation)
-        else:
-            span = tracer.join_trace(operation_name=operation,
-                                     parent_trace_context=context)
+
+        span = tracer.start_trace(operation_name=operation,
+                                  parent_trace_context=context)
     
         span.add_tag('client.http.url', request.full_url)
     

--- a/example/zipkin_like/tracer.py
+++ b/example/zipkin_like/tracer.py
@@ -45,19 +45,14 @@ class Tracer(opentracing.Tracer):
             trace_id_header=glossary.TRACE_ID_HEADER,
             trace_attributes_header_prefix=TRACE_ATTRIBUTES_HEADER_PREFIX)
 
-    def start_trace(self, operation_name, tags=None):
+    def start_trace(self, operation_name, tags=None, parent_trace_context=None):
         """Implements start_trace of opentracing.Tracer."""
-        trace_context = self.trace_context_source.new_root_trace_context()
+        if not parent_trace_context:
+            trace_context = self.trace_context_source.new_root_trace_context()
+        else:
+            trace_context = parent_trace_context
         return self.create_span(operation_name=operation_name,
                                 trace_context=trace_context,
-                                is_client=False, tags=tags)
-
-    def join_trace(self, operation_name, parent_trace_context, tags=None):
-        """Implements join_trace of opentracing.Tracer"""
-        # NOTE: Zipkin-specific behavior - server joins the same span that
-        # was started by the client.
-        return self.create_span(operation_name=operation_name,
-                                trace_context=parent_trace_context,
                                 is_client=False, tags=tags)
 
     def close(self):

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -50,16 +50,16 @@ class APICompatibilityCheckMixin(object):
                                     'city': 'Old New York'})
         tracer.close()
 
-    def test_join_trace(self):
+    def test_continue_trace(self):
         tracer = self.tracer()
         trace_context = tracer.new_root_trace_context()
         assert trace_context is not None
-        span = tracer.join_trace(operation_name='Leela',
-                                 parent_trace_context=trace_context)
+        span = tracer.start_trace(operation_name='Leela',
+                                  parent_trace_context=trace_context)
         span.finish()
-        span = tracer.join_trace(operation_name='Leela',
-                                 parent_trace_context=trace_context,
-                                 tags={'birthplace': 'sewers'})
+        span = tracer.start_trace(operation_name='Leela',
+                                  parent_trace_context=trace_context,
+                                  tags={'birthplace': 'sewers'})
         span.finish()
         tracer.close()
 

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -35,11 +35,14 @@ class Tracer(TraceContextSource, object):
 
     singleton_noop_span = Span(TraceContextSource.singleton_noop_trace_context)
 
-    def start_trace(self, operation_name, tags=None):
-        """Starts a new trace and creates a new root span.
+    def start_trace(self, operation_name, tags=None, parent_trace_context=None):
+        """Start a new trace, or continue an upstream trace in this service.
 
-        This method should be used by services that are instrumented for
-        tracing but did not receive trace ID from upstream request.
+        If no parent_trace_context is provided, start a new trace and return a
+        new root span.
+
+        If provided a parent_trace_context, return a new span which is a child
+        of the given parent trace context.
 
         :param operation_name: the service's own name for the end-point
             that received the request represented by this trace and span.
@@ -48,27 +51,8 @@ class Tracer(TraceContextSource, object):
         :param tags: optional dictionary of Span Tags. The caller is
             expected to give up ownership of that dictionary, because the
             Tracer may use it as is to avoid extra data copying.
-
-        :return: a new root Span
-        """
-        return Tracer.singleton_noop_span
-
-    def join_trace(self, operation_name, parent_trace_context, tags=None):
-        """Joins a trace started elsewhere and creates a new span as a
-        child of the given parent trace context.
-
-        This method should be used by services that receive tracing info
-        from upstream.
-
-        :param operation_name: the service's own name for the end-point
-            that received the request represented by this trace and span.
-            The domain of names must be limited, e.g. do not use UUIDs or
-            entity IDs or timestamps as part of the name.
-        :param parent_trace_context: Trace Context of a client span started
-            elsewhere and whose trace we're joining.
-        :param tags: optional dictionary of Span Tags. The caller is
-            expected to give up ownership of that dictionary, because the
-            Tracer may use it as is to avoid extra data copying.
+        :param parent_trace_context: optional Trace Context of a client span
+            started elsewhere whose trace we're joining.
 
         :return: a new Span
         """

--- a/tests/test_noop_tracer.py
+++ b/tests/test_noop_tracer.py
@@ -26,8 +26,8 @@ from opentracing import Tracer
 def test_tracer():
     tracer = Tracer()
     span = tracer.start_trace(operation_name='root')
-    child = tracer.join_trace(operation_name='child',
-                              parent_trace_context=span.trace_context)
+    child = tracer.start_trace(operation_name='child',
+                               parent_trace_context=span.trace_context)
     assert span == child
     assert span.trace_context == child.trace_context
     fut = tracer.close()


### PR DESCRIPTION
A PR to discuss merging `start_trace`, `join_trace`, and `child_span` as discussed in https://github.com/opentracing/opentracing.github.io/pull/34 and https://github.com/opentracing/opentracing-java/pull/7

The PR only merges `start_trace` and `join_trace`.  This results in the following deduplication:
```
if context is None:
     span = tracer.start_trace(operation_name=operation)
else:
    span = tracer.join_trace(operation_name=operation,
                             parent_trace_context=context)
```
to
```
    span = tracer.start_trace(operation_name=operation,
                             parent_trace_context=context)
````

`child_span` was also mentioned for possible consolidation, but on examination, it seemed to stand well on its own.  `child_span` has a different use-case: continuing a trace within a process, rather than starting/continuing at a service entry point.  I think these two should be differentiated for tracers which might handle sampling, propagation, or reporting differently at service entry points vs internal spans.

One open question is the naming of this method, but I think `start_trace` is still accurate.

@yurishkuro @michaelsembwever @bensigelman thoughts?