### PR TITLE
Remove the Injector/Extractor layer

### DIFF
--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -21,13 +21,12 @@ from __future__ import absolute_import
 from .span import Span  # noqa
 from .span import start_child_span  # noqa
 from .tracer import Tracer  # noqa
-from .propagation import Extractor  # noqa
 from .propagation import Format  # noqa
-from .propagation import Injector  # noqa
 from .propagation import InvalidCarrierException  # noqa
 from .propagation import SplitBinaryCarrier  # noqa
 from .propagation import SplitTextCarrier  # noqa
 from .propagation import TraceCorruptedException  # noqa
+from .propagation import UnsupportedFormatException  # noqa
 
 # Global variable that should be initialized to an instance of real tracer.
 # Note: it should be accessed via 'opentracing.tracer', not via

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -133,15 +133,17 @@ class APICompatibilityCheckMixin(object):
     def test_text_propagation(self):
         with self.tracer().start_span(operation_name='Bender') as span:
             text_carrier = opentracing.SplitTextCarrier()
-            self.tracer().injector(opentracing.Format.SPLIT_TEXT).inject_span(
-                span=span, carrier=text_carrier)
+            self.tracer().inject(
+                span=span,
+                format=opentracing.Format.SPLIT_TEXT,
+                carrier=text_carrier)
             assert type(text_carrier.tracer_state) is dict
             assert (text_carrier.baggage is None or
                     type(text_carrier.baggage) is dict)
-            with self.tracer().extractor(
-                opentracing.Format.SPLIT_TEXT).join_trace(
+            with self.tracer().join(
                 None,
-                carrier=text_carrier
+                format=opentracing.Format.SPLIT_TEXT,
+                carrier=text_carrier,
             ) as reassembled_span:
                 reassembled_span.set_baggage_item(
                     'middle-name', 'Rodriguez')
@@ -149,15 +151,16 @@ class APICompatibilityCheckMixin(object):
     def test_binary_propagation(self):
         with self.tracer().start_span(operation_name='Bender') as span:
             bin_carrier = opentracing.SplitBinaryCarrier()
-            self.tracer().injector(
-                opentracing.Format.SPLIT_BINARY).inject_span(
-                span=span, carrier=bin_carrier)
+            self.tracer().inject(
+                span=span,
+                format=opentracing.Format.SPLIT_BINARY,
+                carrier=bin_carrier)
             assert type(bin_carrier.tracer_state) is bytearray
             assert (bin_carrier.baggage is None or
                     type(bin_carrier.baggage) is bytearray)
-            with self.tracer().extractor(
-                opentracing.Format.SPLIT_BINARY).join_trace(
+            with self.tracer().join(
                 None,
+                format=opentracing.Format.SPLIT_BINARY,
                 carrier=bin_carrier
             ) as reassembled_span:
                 reassembled_span.set_baggage_item(

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -21,69 +21,20 @@
 from __future__ import absolute_import
 
 
-class Injector(object):
-    """An Injector injects Span instances into a format-specific "carrier"
-    object.
+class UnsupportedFormatException(Exception):
+    """UnsupportedFormatException should be used when the provided format
+    value is unknown or disallowed by the Tracer.
 
-    Typically the carrier will then propagate across a process boundary, often
-    via an RPC (though message queues and other IPC mechanisms are also
-    reasonable places to use an Injector).
-
-    See Extractor and Tracer.injector().
+    See Tracer.inject() and Tracer.join().
     """
-
-    def inject_span(self, span, carrier):
-        """inject_span takes `span` and injects it into `carrier`.
-
-        The actual type of `carrier` depends on the `format` value passed to
-        `Tracer.injector()`.
-
-        Implementations may raise opentracing.InvalidCarrierException or any
-        other implementation-specific exception if injection fails.
-
-        :param span: the Span instance to inject
-        :param carrier: the format-specific carrier object to inject into
-        """
-        raise NotImplementedError()
-
-
-class Extractor(object):
-    """An Extractor extracts Span instances from a format-specific "carrier"
-    object.
-
-    Typically the carrier has just arrived across a process boundary, often via
-    an RPC (though message queues and other IPC mechanisms are also reasonable
-    places to use an Extractor).
-
-    See Injector and Tracer.extractor().
-    """
-
-    def join_trace(self, operation_name, carrier):
-        """join_trace returns a Span instance with operation name `operation_name`
-        that's joined to the trace state embedded within `carrier`, or None if
-        no such trace state could be found.
-
-        Implementations may raise opentracing.InvalidCarrierException,
-        opentracing.TraceCorruptedException, or implementation-specific errors
-        if there are more fundamental problems with `carrier`.
-
-        Upon success, the returned Span instance is already started.
-
-        :param operation_name: the operation name for the returned Span (which
-            can be set later via Span.set_operation_name())
-        :param carrier: the format-specific carrier object to extract from
-
-        :return: a Span instance joined to the trace state in `carrier` or None
-            if no such trace state could be found.
-        """
-        raise NotImplementedError()
+    pass
 
 
 class InvalidCarrierException(Exception):
     """InvalidCarrierException should be used when the provided carrier
     instance does not match what the `format` argument requires.
 
-    See Injector and Extractor.
+    See Tracer.inject() and Tracer.join().
     """
     pass
 
@@ -92,33 +43,30 @@ class TraceCorruptedException(Exception):
     """TraceCorruptedException should be used when the underlynig trace state
     is seemingly present but not well-formed.
 
-    See Extractor.join_trace.
+    See Tracer.inject() and Tracer.join().
     """
     pass
 
 
 class Format:
-    """A namespace for builtin Injector/Extractor formats.
+    """A namespace for builtin carrier formats.
 
-    These static constants are intended for use in the Tracer.injector() and
-    Tracer.extractor() methods. E.g.,
+    These static constants are intended for use in the Tracer.inject() and
+    Tracer.join() methods. E.g.,
 
-        tracer.injector(Format.SPLIT_BINARY).inject_span(...)
+        tracer.inject(span, Format.SPLIT_BINARY, split_binary_carrier)
 
     """
 
-    # The SPLIT_BINARY format pairs with an Injector or Extractor that expects
-    # a SplitBinaryCarrier carrier object.
+    # The SPLIT_BINARY format pairs with a SplitBinaryCarrier carrier object.
     SPLIT_BINARY = 'split_binary'
 
-    # The SPLIT_TEXT format pairs with an Injector or Extractor that expects a
-    # SplitTextCarrier carrier object.
+    # The SPLIT_TEXT format pairs with a SplitTextCarrier carrier object.
     SPLIT_TEXT = 'split_text'
 
 
 class SplitBinaryCarrier(object):
-    """The SplitBinaryCarrier is a carrier to be used with Format.SPLIT_BINARY
-    Injectors/Extractors.
+    """The SplitBinaryCarrier is a carrier to be used with Format.SPLIT_BINARY.
 
     The SplitBinaryCarrier has two properties, and each is represented as a
     bytearray:
@@ -138,8 +86,7 @@ class SplitBinaryCarrier(object):
 
 
 class SplitTextCarrier(object):
-    """The SplitTextCarrier is a carrier to be used with Format.SPLIT_BINARY
-    Injectors/Extractors.
+    """The SplitTextCarrier is a carrier to be used with Format.SPLIT_TEXT.
 
     The SplitTextCarrier has two properties, and each is represented as a
     string->string dict:
@@ -156,14 +103,3 @@ class SplitTextCarrier(object):
             {} if tracer_state is None else tracer_state)
         self.baggage = (
             {} if baggage is None else baggage)
-
-
-class _NoopPropagator:
-    def __init__(self, tracer):
-        self._tracer = tracer
-
-    def inject_span(self, span, carrier):
-        pass
-
-    def join_trace(self, operation_name, carrier):
-        return self._tracer._noop_span

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -72,7 +72,7 @@ class Tracer(object):
             is defined by python `==` equality.
         :param carrier: the format-specific carrier object to inject into
         """
-        return None
+        pass
 
     def join(self, operation_name, format, carrier):
         """Returns a Span instance with operation name `operation_name`

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 from concurrent.futures import Future
 from .span import Span
-from .propagation import _NoopPropagator
 
 
 class Tracer(object):
@@ -34,7 +33,6 @@ class Tracer(object):
 
     def __init__(self):
         self._noop_span = Span(self)
-        self._noop_propagator = _NoopPropagator(self)
 
     def start_span(self,
                    operation_name=None,
@@ -58,35 +56,53 @@ class Tracer(object):
         """
         return self._noop_span
 
-    def injector(self, format):
-        """Returns an Injector instance corresponding to `format`.
+    def inject(self, span, format, carrier):
+        """Injects `span` into `carrier`.
 
-        See the opentracing.propagation.Format class/namespace for standard
-        (and required) formats.
+        The type of `carrier` is determined by `format`. See the
+        opentracing.propagation.Format class/namespace for standard (and
+        required) formats.
 
+        Implementations may raise opentracing.UnsupportedFormatException if
+        `format` is unknown or disallowed.
+
+        :param span: the Span instance to inject
         :param format: a python object instance that represents a given
-            Injector format. `format` may be of any type, and `format` equality
+            carrier format. `format` may be of any type, and `format` equality
             is defined by python `==` equality.
-
-        :return: an Injector instance corresponding to `format`, or None if the
-            Tracer implementation does not support `format`.
+        :param carrier: the format-specific carrier object to inject into
         """
-        return self._noop_propagator
+        return None
 
-    def extractor(self, format):
-        """Returns an Extractor instance corresponding to `format`.
+    def join(self, operation_name, format, carrier):
+        """Returns a Span instance with operation name `operation_name`
+        that's joined to the trace state embedded within `carrier`, or None if
+        no such trace state could be found.
 
-        See the opentracing.propagation.Format class/namespace for standard
-        (and required) formats.
+        The type of `carrier` is determined by `format`. See the
+        opentracing.propagation.Format class/namespace for standard (and
+        required) formats.
 
+        Implementations may raise opentracing.UnsupportedFormatException if
+        `format` is unknown or disallowed.
+
+        Implementations may raise opentracing.InvalidCarrierException,
+        opentracing.TraceCorruptedException, or implementation-specific errors
+        if there are problems with `carrier`.
+
+        Upon success, the returned Span instance is already started.
+
+        :param operation_name: the operation name for the returned Span (which
+            can be set later via Span.set_operation_name())
         :param format: a python object instance that represents a given
-            Extractor format. `format` may be of any type, and `format`
-            equality is defined by python `==` equality.
+            carrier format. `format` may be of any type, and `format` equality
+            is defined by python `==` equality.
+        :param carrier: the format-specific carrier object to join with
 
-        :return: an Extractor instance corresponding to `format`, or None if
-            the Tracer implementation does not support `format`.
+        :return: a Span instance joined to the trace state in `carrier` or None
+            if no such trace state could be found.
         """
-        return self._noop_propagator
+        return self._noop_span
 
     def flush(self):
         """Flushes any trace data that may be buffered in memory, presumably

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -60,33 +60,29 @@ def test_span():
     parent.finish()
 
 
-def test_injector():
+def test_inject():
     tracer = Tracer()
     span = tracer.start_span()
 
     bin_carrier = SplitBinaryCarrier()
-    tracer.injector(Format.SPLIT_BINARY).inject_span(
-        span=span, carrier=bin_carrier)
+    tracer.inject(span=span, format=Format.SPLIT_BINARY, carrier=bin_carrier)
     assert bin_carrier.tracer_state == bytearray()
     assert bin_carrier.baggage == bytearray()
 
     text_carrier = SplitTextCarrier()
-    tracer.injector(Format.SPLIT_TEXT).inject_span(
-        span=span, carrier=text_carrier)
+    tracer.inject(span=span, format=Format.SPLIT_TEXT, carrier=text_carrier)
     assert text_carrier.tracer_state == {}
     assert text_carrier.baggage == {}
 
 
-def test_extractor():
+def test_join():
     tracer = Tracer()
     noop_span = tracer._noop_span
 
     bin_carrier = SplitBinaryCarrier()
-    span = tracer.extractor(Format.SPLIT_BINARY).join_trace(
-        'op_name', carrier=bin_carrier)
+    span = tracer.join('op_name', Format.SPLIT_BINARY, carrier=bin_carrier)
     assert noop_span == span
 
     text_carrier = SplitTextCarrier()
-    span = tracer.extractor(Format.SPLIT_TEXT).join_trace(
-        'op_name', carrier=text_carrier)
+    span = tracer.join('op_name', Format.SPLIT_TEXT, carrier=text_carrier)
     assert noop_span == span


### PR DESCRIPTION
Per https://github.com/opentracing/opentracing.github.io/issues/70, we are getting rid of injector()/extractor() and the respective classes/interfaces in favor of Tracer.inject() and Tracer.join().