### PR TITLE
Simple carriers for Python

### DIFF
--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -23,8 +23,6 @@ from .span import start_child_span  # noqa
 from .tracer import Tracer  # noqa
 from .propagation import Format  # noqa
 from .propagation import InvalidCarrierException  # noqa
-from .propagation import SplitBinaryCarrier  # noqa
-from .propagation import SplitTextCarrier  # noqa
 from .propagation import TraceCorruptedException  # noqa
 from .propagation import UnsupportedFormatException  # noqa
 

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -132,17 +132,14 @@ class APICompatibilityCheckMixin(object):
 
     def test_text_propagation(self):
         with self.tracer().start_span(operation_name='Bender') as span:
-            text_carrier = opentracing.SplitTextCarrier()
+            text_carrier = {}
             self.tracer().inject(
                 span=span,
-                format=opentracing.Format.SPLIT_TEXT,
+                format=opentracing.Format.TEXT_MAP,
                 carrier=text_carrier)
-            assert type(text_carrier.tracer_state) is dict
-            assert (text_carrier.baggage is None or
-                    type(text_carrier.baggage) is dict)
             with self.tracer().join(
                 None,
-                format=opentracing.Format.SPLIT_TEXT,
+                format=opentracing.Format.TEXT_MAP,
                 carrier=text_carrier,
             ) as reassembled_span:
                 reassembled_span.set_baggage_item(
@@ -150,17 +147,14 @@ class APICompatibilityCheckMixin(object):
 
     def test_binary_propagation(self):
         with self.tracer().start_span(operation_name='Bender') as span:
-            bin_carrier = opentracing.SplitBinaryCarrier()
+            bin_carrier = bytearray()
             self.tracer().inject(
                 span=span,
-                format=opentracing.Format.SPLIT_BINARY,
+                format=opentracing.Format.BINARY,
                 carrier=bin_carrier)
-            assert type(bin_carrier.tracer_state) is bytearray
-            assert (bin_carrier.baggage is None or
-                    type(bin_carrier.baggage) is bytearray)
             with self.tracer().join(
                 None,
-                format=opentracing.Format.SPLIT_BINARY,
+                format=opentracing.Format.BINARY,
                 carrier=bin_carrier
             ) as reassembled_span:
                 reassembled_span.set_baggage_item(

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -54,52 +54,16 @@ class Format:
     These static constants are intended for use in the Tracer.inject() and
     Tracer.join() methods. E.g.,
 
-        tracer.inject(span, Format.SPLIT_BINARY, split_binary_carrier)
+        tracer.inject(span, Format.BINARY, binary_carrier)
 
     """
 
-    # The SPLIT_BINARY format pairs with a SplitBinaryCarrier carrier object.
-    SPLIT_BINARY = 'split_binary'
+    # The BINARY format injects Spans into and joins Spans from an opaque
+    # bytearray carrier. For both Tracer.inject() and Tracer.join() the carrier
+    # should be a bytearray instance. Tracer.inject() must append to the
+    # bytearray carrier (rather than replace its contents).
+    BINARY = 'binary'
 
-    # The SPLIT_TEXT format pairs with a SplitTextCarrier carrier object.
-    SPLIT_TEXT = 'split_text'
-
-
-class SplitBinaryCarrier(object):
-    """The SplitBinaryCarrier is a carrier to be used with Format.SPLIT_BINARY.
-
-    The SplitBinaryCarrier has two properties, and each is represented as a
-    bytearray:
-     - tracer_state: Tracer-specific context that must cross process
-       boundaries. For example, in Dapper this would include a trace_id, a
-       span_id, and a bitmask representing the sampling status for the given
-       trace.
-     - baggage: any Baggage items for the encoded Span (per
-       Span.set_baggage_item()).
-    """
-
-    def __init__(self, tracer_state=None, baggage=None):
-        self.tracer_state = (
-            bytearray() if tracer_state is None else tracer_state)
-        self.baggage = (
-            bytearray() if baggage is None else baggage)
-
-
-class SplitTextCarrier(object):
-    """The SplitTextCarrier is a carrier to be used with Format.SPLIT_TEXT.
-
-    The SplitTextCarrier has two properties, and each is represented as a
-    string->string dict:
-     - tracer_state: Tracer-specific context that must cross process
-       boundaries. For example, in Dapper this would include a trace_id, a
-       span_id, and a bitmask representing the sampling status for the given
-       trace.
-     - baggage: any Baggage items for the encoded Span (per
-       Span.set_baggage_item()).
-    """
-
-    def __init__(self, tracer_state=None, baggage=None):
-        self.tracer_state = (
-            {} if tracer_state is None else tracer_state)
-        self.baggage = (
-            {} if baggage is None else baggage)
+    # The TEXT_MAP format injects Spans into and joins Spans from a python dict
+    # carrier that maps from strings to strings.
+    TEXT_MAP = 'text_map'

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -66,4 +66,13 @@ class Format:
 
     # The TEXT_MAP format injects Spans into and joins Spans from a python dict
     # carrier that maps from strings to strings.
+    #
+    # NOTE: Since HTTP headers are a particularly important use case for the
+    # TEXT_MAP carrier, dict key parameters identify their respective values in
+    # a case-insensitive manner.
+    # 
+    # NOTE: The TEXT_MAP carrier dict may contain unrelated data (e.g.,
+    # arbitrary HTTP headers). As such, the Tracer implementation should use a
+    # prefix or other convention to distinguish Tracer-specific key:value
+    # pairs.
     TEXT_MAP = 'text_map'

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -21,8 +21,6 @@
 from __future__ import absolute_import
 import mock
 from opentracing import Format
-from opentracing import SplitBinaryCarrier
-from opentracing import SplitTextCarrier
 from opentracing import Tracer
 from opentracing.ext import tags
 
@@ -64,25 +62,23 @@ def test_inject():
     tracer = Tracer()
     span = tracer.start_span()
 
-    bin_carrier = SplitBinaryCarrier()
-    tracer.inject(span=span, format=Format.SPLIT_BINARY, carrier=bin_carrier)
-    assert bin_carrier.tracer_state == bytearray()
-    assert bin_carrier.baggage == bytearray()
+    bin_carrier = bytearray()
+    tracer.inject(span=span, format=Format.BINARY, carrier=bin_carrier)
+    assert bin_carrier == bytearray()
 
-    text_carrier = SplitTextCarrier()
-    tracer.inject(span=span, format=Format.SPLIT_TEXT, carrier=text_carrier)
-    assert text_carrier.tracer_state == {}
-    assert text_carrier.baggage == {}
+    text_carrier = {}
+    tracer.inject(span=span, format=Format.TEXT_MAP, carrier=text_carrier)
+    assert text_carrier == {}
 
 
 def test_join():
     tracer = Tracer()
     noop_span = tracer._noop_span
 
-    bin_carrier = SplitBinaryCarrier()
-    span = tracer.join('op_name', Format.SPLIT_BINARY, carrier=bin_carrier)
+    bin_carrier = bytearray()
+    span = tracer.join('op_name', Format.BINARY, carrier=bin_carrier)
     assert noop_span == span
 
-    text_carrier = SplitTextCarrier()
-    span = tracer.join('op_name', Format.SPLIT_TEXT, carrier=text_carrier)
+    text_carrier = {}
+    span = tracer.join('op_name', Format.TEXT_MAP, carrier=text_carrier)
     assert noop_span == span


### PR DESCRIPTION
@yurishkuro curious what you think about this... I realize we just went through the exercise of moving to interface-only carriers in https://github.com/opentracing/basictracer-go/pull/15, but for some reason it felt too heavy-handed comment-wise in Python. I guess it's a tradeoff between flexibility and comprehensibility (and perhaps I'm more concerned about the latter).

(C.f.: https://github.com/opentracing/opentracing.github.io/issues/73)