### PR TITLE
Add method to canonicalize baggage keys

### DIFF
--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -119,7 +119,10 @@ class Span(object):
         calls, so this feature must be used with care.
 
         Note 3: keys are case-insensitive, to allow propagation via HTTP
-        headers. Keys must match regexp `(?i:[a-z0-9][-a-z0-9]*)`
+        headers. Keys must match regexp `(?i:[a-z0-9][-a-z0-9]*)`. See
+        `canonicalize_baggage_key()` for a way of checking and canonicalizing
+        a key. If a key doesn't meet these guidelines, the behavior of
+        `set_baggage_item()` will be undefined.
 
         :param key: Baggage item key
         :type key: str
@@ -199,13 +202,13 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
     )
 
 
-baggage_key_re = re.compile('^(?i)([a-z0-9][-a-z0-9]*)$')
+_baggage_key_re = re.compile('^(?i)([a-z0-9][-a-z0-9]*)$')
 
 def canonicalize_baggage_key(key):
     """canonicalize_baggage_key returns a canonicalized key if it's valid.
 
     :param key: a string that is expected to match the pattern specified by
-        `get_baggage_item`.
+        `get_baggage_item()`.
 
     :return: Returns the canonicalized key if it's valid, otherwise it returns
         None.

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -213,6 +213,6 @@ def canonicalize_baggage_key(key):
     :return: Returns the canonicalized key if it's valid, otherwise it returns
         None.
     """
-    if baggage_key_re.match(key) is not None:
+    if _baggage_key_re.match(key) is not None:
         return key.lower()
     return None

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+import re
 
 class Span(object):
     """
@@ -196,3 +197,19 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
         tags=tags,
         start_time=start_time
     )
+
+
+baggage_key_re = re.compile('^(?i)([a-z0-9][-a-z0-9]*)$')
+
+def canonicalize_baggage_key(key):
+    """canonicalize_baggage_key returns a canonicalized key if it's valid.
+
+    :param key: a string that is expected to match the pattern specified by
+        `get_baggage_item`.
+
+    :return: Returns the canonicalized key if it's valid, otherwise it returns
+        None.
+    """
+    if baggage_key_re.match(key) is not None:
+        return key.lower()
+    return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Uber Technologies, Inc.
+# Copyright (c) 2015 The OpenTracing Authors.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -17,17 +17,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from __future__ import absolute_import
-from .span import Span  # noqa
-from .span import start_child_span  # noqa
-from .span import canonicalize_baggage_key #noqa
-from .tracer import Tracer  # noqa
-from .propagation import Format  # noqa
-from .propagation import InvalidCarrierException  # noqa
-from .propagation import TraceCorruptedException  # noqa
-from .propagation import UnsupportedFormatException  # noqa
 
-# Global variable that should be initialized to an instance of real tracer.
-# Note: it should be accessed via 'opentracing.tracer', not via
-# 'from opentracing import tracer', the latter seems to take a copy.
-tracer = Tracer()
+from __future__ import absolute_import
+from opentracing import canonicalize_baggage_key
+
+def test_canonicalize_baggage_key():
+    badKey = "some-weird-sign!#"
+    assert canonicalize_baggage_key(badKey) == None
+
+    badKey2 = "-another-sign"
+    assert canonicalize_baggage_key(badKey2) == None
+
+    goodKey = "000-Capitalized-9"
+    canonicalKey = canonicalize_baggage_key(goodKey)
+    assert canonicalKey == goodKey.lower()


### PR DESCRIPTION
The OpenTracing spec specifies that baggage keys should match a
specified regex and be case insensitive. By adding a method to the
package to canonicalize keys, we can ensure that all OpenTracing
implementations have a consistent way of meeting the spec.

Per https://github.com/opentracing/opentracing-python/issues/22

Pardon my python, it's fairly rusty.