### PR TITLE
Rename ChildOf/FollowsFrom to child_of/follows_from

### DIFF
--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -20,8 +20,8 @@
 from __future__ import absolute_import
 from .span import Span  # noqa
 from .span import SpanContext  # noqa
-from .tracer import ChildOf  # noqa
-from .tracer import FollowsFrom  # noqa
+from .tracer import child_of  # noqa
+from .tracer import follows_from  # noqa
 from .tracer import Reference  # noqa
 from .tracer import ReferenceType  # noqa
 from .tracer import Tracer  # noqa

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -56,11 +56,11 @@ class APICompatibilityCheckMixin(object):
         assert parent_span is not None
         span = tracer.start_span(
             operation_name='Leela',
-            references=opentracing.ChildOf(parent_span.context))
+            references=opentracing.child_of(parent_span.context))
         span.finish()
         span = tracer.start_span(
             operation_name='Leela',
-            references=opentracing.ChildOf(parent_span.context),
+            references=opentracing.follows_from(parent_span.context),
             tags={'birthplace': 'sewers'})
         span.finish()
         parent_span.finish()

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -48,13 +48,13 @@ class SpanContextCorruptedException(Exception):
     pass
 
 
-class Format:
+class Format(object):
     """A namespace for builtin carrier formats.
 
     These static constants are intended for use in the Tracer.inject() and
     Tracer.extract() methods. E.g.,
 
-        tracer.inject(span, Format.BINARY, binary_carrier)
+        tracer.inject(span.context, Format.BINARY, binary_carrier)
 
     """
 

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -20,7 +20,7 @@
 
 from __future__ import absolute_import
 import mock
-from opentracing import ChildOf
+from opentracing import child_of
 from opentracing import Format
 from opentracing import Tracer
 from opentracing.ext import tags
@@ -29,7 +29,7 @@ from opentracing.ext import tags
 def test_span():
     tracer = Tracer()
     parent = tracer.start_span('parent')
-    child = tracer.start_span('test', references=ChildOf(parent.context))
+    child = tracer.start_span('test', references=child_of(parent.context))
     assert parent == child
     child.log_event('cache_hit', ['arg1', 'arg2'])
 

--- a/tests/test_noop_tracer.py
+++ b/tests/test_noop_tracer.py
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-from opentracing import ChildOf
+from opentracing import child_of
 from opentracing import Tracer
 
 
@@ -27,5 +27,5 @@ def test_tracer():
     tracer = Tracer()
     span = tracer.start_span(operation_name='root')
     child = tracer.start_span(operation_name='child',
-                              references=ChildOf(span))
+                              references=child_of(span))
     assert span == child


### PR DESCRIPTION
Also:
  - rename `span_context` to `referee` in Reference
  - document expected behavior when `referee=None`