### PR TITLE
Add an HTTP_HEADERS format

### DIFF
--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -58,17 +58,36 @@ class Format(object):
 
     """
 
-    # The BINARY format injects Spans into and extracts SpanContexts from an
-    # opaque bytearray carrier. For both Tracer.inject() and Tracer.extract()
-    # the carrier should be a bytearray instance. Tracer.inject() must append
-    # to the bytearray carrier (rather than replace its contents).
+    # The BINARY format represents SpanContexts in an opaque bytearray carrier.
+    #
+    # For both Tracer.inject() and Tracer.extract() the carrier should be a
+    # bytearray instance. Tracer.inject() must append to the bytearray carrier
+    # (rather than replace its contents).
     BINARY = 'binary'
 
-    # The TEXT_MAP format injects Spans into and extracts SpanContexts from a
-    # python dict carrier that maps from strings to strings.
+    # The TEXT_MAP format represents SpanContexts in a python dict mapping from
+    # strings to strings.
+    #
+    # Both the keys and the values have unrestricted character sets (unlike the
+    # HTTP_HEADERS format).
     #
     # NOTE: The TEXT_MAP carrier dict may contain unrelated data (e.g.,
-    # arbitrary HTTP headers). As such, the Tracer implementation should use a
+    # arbitrary gRPC metadata). As such, the Tracer implementation should use a
     # prefix or other convention to distinguish Tracer-specific key:value
     # pairs.
     TEXT_MAP = 'text_map'
+
+    # The HTTP_HEADERS format represents SpanContexts in a python dict mapping
+    # from character-restricted strings to strings.
+    #
+    # Keys and values in the HTTP_HEADERS carrier must be suitable for use as
+    # HTTP headers (without modification or further escaping). That is, the
+    # keys have a greatly restricted character set, casing for the keys may not
+    # be preserved by various intermediaries, and the values should be
+    # URL-escaped.
+    #
+    # NOTE: The HTTP_HEADERS carrier dict may contain unrelated data (e.g.,
+    # arbitrary gRPC metadata). As such, the Tracer implementation should use a
+    # prefix or other convention to distinguish Tracer-specific key:value
+    # pairs.
+    HTTP_HEADERS = 'http_headers'

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -149,7 +149,7 @@ class Reference(namedtuple('Reference', ['type', 'referee'])):
     contains no tracing information and as a result tracer.extract()
     returns None:
 
-        parent_ref = tracer.extract(opentracing.TEXT_MAP, request.headers)
+        parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
         span = tracer.start_span(
             'operation', references=child_of(parent_ref)
         )

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -38,6 +38,7 @@ class Tracer(object):
 
     def start_span(self,
                    operation_name=None,
+                   child_of=None,
                    references=None,
                    tags=None,
                    start_time=None):
@@ -53,14 +54,24 @@ class Tracer(object):
 
             tracer.start_span(
                 '...',
-                references=opentracing.child_of(parent_span.context))
+                child_of=parent_span)
+
+
+        Starting a child Span in a more verbose way:
+
+            tracer.start_span(
+                '...',
+                references=[opentracing.child_of(parent_span)])
 
 
         :param operation_name: name of the operation represented by the new
             span from the perspective of the current service.
-        :param references: (optional) either a single Reference object or a
-            list of Reference objects that identify one or more parent
-            SpanContexts. (See the Reference documentation for detail)
+        :param child_of: (optional) a Span or SpanContext instance representing
+            the parent in a REFERENCE_CHILD_OF Reference. If specified, the
+            `references` parameter must be omitted.
+        :param references: (optional) a list of Reference objects that identify
+            one or more parent SpanContexts. (See the Reference documentation
+            for detail)
         :param tags: an optional dictionary of Span Tags. The caller gives up
             ownership of that dictionary, because the Tracer may use it as-is
             to avoid extra data copying.
@@ -196,7 +207,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
     """
     return parent_span.tracer.start_span(
         operation_name=operation_name,
-        references=child_of(parent_span.context),
+        child_of=parent_span,
         tags=tags,
         start_time=start_time
     )


### PR DESCRIPTION
Also, update .py to use a `child_of` param instead of overloading `references` as before.