### PR TITLE
Add a better default log() impl

### DIFF
--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -218,11 +218,11 @@ class Span(object):
     def log(self, **kwargs):
         """DEPRECATED"""
         key_values = {}
-        if kwargs["event"] is not None:
-            key_values["event"] = kwargs["event"]
-        if kwargs["payload"] is not None:
-            key_values["payload"] = kwargs["payload"]
+        if kwargs['event'] is not None:
+            key_values['event'] = kwargs['event']
+        if kwargs['payload'] is not None:
+            key_values['payload'] = kwargs['payload']
         timestamp = None
-        if kwargs["timestamp"] is not None:
-            timestamp = kwargs["timestamp"]
+        if kwargs['timestamp'] is not None:
+            timestamp = kwargs['timestamp']
         return self.log_kv(key_values, timestamp)

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -217,4 +217,12 @@ class Span(object):
 
     def log(self, **kwargs):
         """DEPRECATED"""
-        return self.log_kv(kwargs)
+        key_values = {}
+        if kwargs["event"] is not None:
+            key_values["event"] = kwargs["event"]
+        if kwargs["payload"] is not None:
+            key_values["payload"] = kwargs["payload"]
+        timestamp = None
+        if kwargs["timestamp"] is not None:
+            timestamp = kwargs["timestamp"]
+        return self.log_kv(key_values, timestamp)


### PR DESCRIPTION
Since this is a deprecated method, the main task should be to translate to log_kv rather than blindly pass through.

cc @yurishkuro 