### PR TITLE
Implement ActiveSpanSource support.

### DIFF
--- a/opentracing/ext/threadlocalspansource.py
+++ b/opentracing/ext/threadlocalspansource.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from threading import Lock, local
+from ..span import ActiveSpan
+from ..span import ActiveSpanContinuation
+from ..tracer import ActiveSpanSource
+
+
+class ThreadLocalActiveSpanSource(ActiveSpanSource):
+    """
+    A simple ActiveSpanSource implementation built on top of
+    Python's thread-local storage.
+    """
+
+    def __init__(self):
+        self._tls_snapshot = local()
+
+    @property
+    def active_span(self):
+        return getattr(self._tls_snapshot, 'active_span', None)
+
+    def _set_active_span(self, active_span):
+        self._tls_snapshot.active_span = active_span
+
+    def make_active(self, span):
+        return ThreadLocalActiveSpan(self, span, _RefCount(1))
+
+
+class _RefCount(object):
+    def __init__(self, initial_value):
+        self._value = initial_value
+        self._lock = Lock()
+
+    def increment_and_get(self):
+        with self._lock:
+            self._value += 1
+            return self._value
+
+    def decrement_and_get(self):
+        with self._lock:
+            self._value -= 1
+            return self._value
+
+
+class ThreadLocalActiveSpan(ActiveSpan):
+    """
+    A simple ActiveSpan implementation that relies on
+    Python's thread-local storage.
+    """
+    def __init__(self, source, wrapped, refcount):
+        super(ThreadLocalActiveSpan, self).__init__(wrapped)
+        self._source = source
+        self._refcount = refcount
+
+        self._to_restore = source.active_span
+        source._set_active_span(self)
+
+    def deactivate(self):
+        if self._source.active_span is not self:
+            # This shouldn't happen if users call methods in the expected
+            # order. Bail out.
+            return
+
+        self._source._set_active_span(self._to_restore)
+
+        if self._refcount.decrement_and_get() == 0:
+            self.wrapped.finish()
+
+    def capture(self):
+        return ThreadLocalActiveSpanContinuation(self)
+
+
+class ThreadLocalActiveSpanContinuation(ActiveSpanContinuation):
+    def __init__(self, active_span):
+        super(ThreadLocalActiveSpanContinuation, self).__init__()
+        self._active_span = active_span
+        self._active_span._refcount.increment_and_get()
+
+    def activate(self):
+        return ThreadLocalActiveSpan(
+            self._active_span._source,
+            self._active_span.wrapped,
+            self._active_span._refcount
+        )

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -52,27 +52,15 @@ class SpanContext(object):
         return SpanContext.EMPTY_BAGGAGE
 
 
-class Span(object):
+class BaseSpan(object):
     """
-    Span represents a unit of work executed on behalf of a trace. Examples of
+    BaseSpan represents the OpenTracing specification's span contract,
+    which is a unit of work executed on behalf of a trace. Examples of
     spans include a remote procedure call, or a in-process method call to a
     sub-component. Every span in a trace may have zero or more causal parents,
     and these relationships transitively form a DAG. It is common for spans to
     have at most one parent, and thus most traces are merely tree structures.
-
-    Span implements a Context Manager API that allows the following usage:
-
-    .. code-block:: python
-
-        with tracer.start_span(operation_name='go_fishing') as span:
-            call_some_service()
-
-    In the Context Manager syntax it's not necessary to call span.finish()
     """
-
-    def __init__(self, tracer, context):
-        self._tracer = tracer
-        self._context = context
 
     @property
     def context(self):
@@ -83,15 +71,7 @@ class Span(object):
 
         :return: returns the SpanContext associated with this Span.
         """
-        return self._context
-
-    @property
-    def tracer(self):
-        """Provides access to the Tracer that created this Span.
-
-        :return: returns the Tracer that created this Span.
-        """
-        return self._tracer
+        return None
 
     def set_operation_name(self, operation_name):
         """Changes the operation name.
@@ -100,18 +80,6 @@ class Span(object):
         :return: Returns the Span itself, for call chaining.
         """
         return self
-
-    def finish(self, finish_time=None):
-        """Indicates that the work represented by this span has completed or
-        terminated.
-
-        With the exception of the `Span.context` property, the semantics of all
-        other Span methods are undefined after `finish()` has been invoked.
-
-        :param finish_time: an explicit Span finish timestamp as a unix
-            timestamp per time.time()
-        """
-        pass
 
     def set_tag(self, key, value):
         """Attaches a key/value pair to the span.
@@ -189,6 +157,72 @@ class Span(object):
         """
         return None
 
+    def log_event(self, event, payload=None):
+        """DEPRECATED"""
+        if payload is None:
+            return self.log_kv({'event': event})
+        else:
+            return self.log_kv({'event': event, 'payload': payload})
+
+    def log(self, **kwargs):
+        """DEPRECATED"""
+        key_values = {}
+        if 'event' in kwargs:
+            key_values['event'] = kwargs['event']
+        if 'payload' in kwargs:
+            key_values['payload'] = kwargs['payload']
+        timestamp = None
+        if 'timestamp' in kwargs:
+            timestamp = kwargs['timestamp']
+        return self.log_kv(key_values, timestamp)
+
+
+class Span(BaseSpan):
+    """Span represents a OpenTracing span's implementation, which is
+    *manually propagated* within the given process. Most of this API
+    lives in BaseSpan.
+
+    Span implements a Context Manager API that allows the following usage:
+
+    .. code-block:: python
+
+        with tracer.start_span(operation_name='go_fishing') as span:
+            call_some_service()
+
+    In the Context Manager syntax it's not necessary to call span.finish()
+    """
+    def __init__(self, tracer, context):
+        self._tracer = tracer
+        self._context = context
+
+    @property
+    def context(self):
+        """Provides access to the SpanContext associated with this Span.
+
+        :return: returns the SpanContext associated with this Span.
+        """
+        return self._context
+
+    @property
+    def tracer(self):
+        """Provides access to the Tracer that created this Span.
+
+        :return: returns the Tracer that created this Span.
+        """
+        return self._tracer
+
+    def finish(self, finish_time=None):
+        """Indicates that the work represented by this span has completed or
+        terminated.
+
+        With the exception of the `Span.context` property, the semantics of all
+        other Span methods are undefined after `finish()` has been invoked.
+
+        :param finish_time: an explicit Span finish timestamp as a unix
+            timestamp per time.time()
+        """
+        pass
+
     def __enter__(self):
         """Invoked when span is used as a context manager.
 
@@ -210,21 +244,166 @@ class Span(object):
                 })
         self.finish()
 
-    def log_event(self, event, payload=None):
-        """DEPRECATED"""
-        if payload is None:
-            return self.log_kv({'event': event})
-        else:
-            return self.log_kv({'event': event, 'payload': payload})
 
-    def log(self, **kwargs):
-        """DEPRECATED"""
-        key_values = {}
-        if 'event' in kwargs:
-            key_values['event'] = kwargs['event']
-        if 'payload' in kwargs:
-            key_values['payload'] = kwargs['payload']
-        timestamp = None
-        if 'timestamp' in kwargs:
-            timestamp = kwargs['timestamp']
-        return self.log_kv(key_values, timestamp)
+class ActiveSpan(BaseSpan):
+    """ActiveSpan represents a OpenTracing span's implementation,
+    wrapping a Span object, layering on in-process propagation capabilities.
+
+    In any given thread there is at most one active span primarily
+    responsible for the work accomplished by the surrounding application code.
+    The ActiveSpan may be accessed via the ActiveSpanSource.active_span
+    property. If the application needs to defer work that should be part of
+    the same Span, the Source provides a ActiveSpan.capture() method that
+    returns an ActiveSpanContinuation; this continuation may be used to
+    re-activate and continue the Span in that other thread.
+
+    ActiveSpan implements a Context Manager API that allows the following
+    usage:
+
+    .. code-block:: python
+
+        with tracer.start_active_span(operation_name='go_fishing') as span:
+            call_some_service()
+
+    In the Context Manager syntax it's not necessary to call span.deactivate()
+    """
+
+    def __init__(self, wrapped):
+        self._wrapped = wrapped
+        self._noop_continuation = ActiveSpanContinuation()
+
+    def deactivate(self):
+        """Mark the end of the active period for the current thread and
+        ActiveSpan. When the last ActiveSpan is deactivated for a given Span,
+        it is automatically finished with a call to Span.finish().
+        """
+        pass
+
+    def capture(self):
+        """Capture a new ActiveSpanContinuation associated with this
+        ActiveSpan and Span. The ActiveSpanContinuation may be used as data
+        in a closure or callback function where the ActiveSpan may be resumed
+        and reactivated.
+
+        IMPORTANT: the caller MUST call ActiveSpanContinuation.activate() and
+        call ActiveSpan.deactivate() or the associated Span will never be
+        finished. That is, calling capture() increments a refcount that must be
+        decremented somewhere else.
+        """
+        return self._noop_continuation
+
+    @property
+    def wrapped(self):
+        """Provides access to the wrapped Span this active
+        object holds.
+
+        :return: returns the wrapped Span.
+        """
+        return self._wrapped
+
+    @property
+    def context(self):
+        """Provides access to the wrapped Span's context.
+
+        :return: returns the wrapped Span's context.
+        """
+        return self._wrapped.context
+
+    def set_operation_name(self, operation_name):
+        """Changes the operation name of the wrapped Span.
+
+        :param operation_name: the new operation name
+        :return: Returns the ActiveSpan itself, for call chaining.
+        """
+        self._wrapped.set_operation_name(operation_name)
+        return self
+
+    def set_tag(self, key, value):
+        """Attaches a key/value pair to the wrapped Span.
+
+        :return: Returns the ActiveSpan itself, for call chaining.
+        :rtype: ActiveSpan
+        """
+        self._wrapped.set_tag(key, value)
+        return self
+
+    def log_kv(self, key_values, timestamp=None):
+        """Adds a log record to the wrapped Span.
+
+        :param key_values: A dict of string keys and values of any type
+        :type key_values: dict
+
+        :param timestamp: A unix timestamp per time.time(); current time if
+            None
+        :type timestamp: float
+
+        :return: Returns the ActiveSpan itself, for call chaining.
+        :rtype: ActiveSpan
+        """
+        self._wrapped.log_kv(key_values, timestamp)
+        return self
+
+    def set_baggage_item(self, key, value):
+        """Stores a Baggage item in the wrapped Span as a key/value pair.
+
+        :param key: Baggage item key
+        :type key: str
+
+        :param value: Baggage item value
+        :type value: str
+
+        :rtype : ActiveSpan
+        :return: itself, for chaining the calls.
+        """
+        self._wrapped.set_baggage_item(key, value)
+        return self
+
+    def get_baggage_item(self, key):
+        """Retrieves value of the Baggage item with the given key
+        for the wrapped Span.
+
+        :param key: key of the Baggage item
+        :type key: str
+
+        :rtype : str
+        :return: value of the Baggage item with given key, or None.
+        """
+        return self._wrapped.get_baggage_item(key)
+
+    def __enter__(self):
+        """Invoked when the span is used as a context manager.
+
+        :return: returns the ActiveSpan itself
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Ends context manager and calls deactive() on the active span.
+
+        If exception has occurred during execution, it is automatically added
+        as a tag to the wrapped span.
+        """
+        if exc_type:
+            self.log_kv({
+                'python.exception.type': exc_type,
+                'python.exception.val': exc_val,
+                'python.exception.tb': exc_tb,
+                })
+        self.deactivate()
+
+
+class ActiveSpanContinuation(object):
+    """An ActiveSpanContinuation can be used *once* to activate a Span, then
+    deactivate when processing activity moves on to another Span
+    (in practice, this active period typically extends for the length
+    of a deferred async closure invocation).
+    """
+
+    def activate(self):
+        """Make the Span encapsulated by this ActiveSpanContinuation
+        active and return it.
+
+        :rtype : ActiveSpan
+        :return: The newly-activated ActiveSpan.
+        """
+        return ActiveSpan(BaseSpan())

--- a/tests/test_noop_active_source.py
+++ b/tests/test_noop_active_source.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2016 The OpenTracing Authors.
-#
-# Copyright (c) 2015 Uber Technologies, Inc.
+# Copyright (c) 2017 The OpenTracing Authors.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,23 +17,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-from __future__ import absolute_import
-from .span import ActiveSpan  # noqa
-from .span import Span  # noqa
-from .span import SpanContext  # noqa
-from .tracer import ActiveSpanSource  # noqa
-from .tracer import child_of  # noqa
-from .tracer import follows_from  # noqa
-from .tracer import Reference  # noqa
-from .tracer import ReferenceType  # noqa
-from .tracer import Tracer  # noqa
-from .tracer import start_child_span  # noqa
-from .propagation import Format  # noqa
-from .propagation import InvalidCarrierException  # noqa
-from .propagation import SpanContextCorruptedException  # noqa
-from .propagation import UnsupportedFormatException  # noqa
 
-# Global variable that should be initialized to an instance of real tracer.
-# Note: it should be accessed via 'opentracing.tracer', not via
-# 'from opentracing import tracer', the latter seems to take a copy.
-tracer = Tracer()
+from __future__ import absolute_import
+from opentracing import ActiveSpanSource
+
+
+def test_active_span_source():
+    source = ActiveSpanSource()
+    active_span = source.make_active(None)
+    assert active_span == source.active_span

--- a/tests/test_noop_active_span.py
+++ b/tests/test_noop_active_span.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2016 The OpenTracing Authors.
+#
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+import mock
+from opentracing import child_of
+from opentracing import Tracer
+from opentracing.ext import tags
+
+
+def test_span():
+    tracer = Tracer()
+    parent = tracer.start_active_span('parent')
+    child = tracer.start_active_span('test',
+                                     references=child_of(parent.context))
+    assert parent == child
+
+    with mock.patch.object(parent, 'deactivate') as deactivate:
+        with mock.patch.object(parent, 'log_event') as log_event:
+            with mock.patch.object(parent, 'log_kv') as log_kv:
+                try:
+                    with parent:
+                        raise ValueError()
+                except ValueError:
+                    pass
+
+                assert deactivate.call_count == 1
+                assert log_event.call_count == 0
+                assert log_kv.call_count == 1
+
+    with mock.patch.object(parent, 'deactivate') as deactivate:
+        with mock.patch.object(parent, 'log_kv') as log_kv:
+            with parent:
+                pass
+            assert deactivate.call_count == 1
+            assert log_kv.call_count == 0
+
+    parent.set_tag('x', 'y').set_tag('z', 1)  # test chaining
+    parent.set_tag(tags.PEER_SERVICE, 'test-service')
+    parent.set_tag(tags.PEER_HOST_IPV4, 127 << 24 + 1)
+    parent.set_tag(tags.PEER_HOST_IPV6, '::')
+    parent.set_tag(tags.PEER_HOSTNAME, 'uber.com')
+    parent.set_tag(tags.PEER_PORT, 123)
+    parent.deactivate()
+
+
+def test_wrapped():
+    tracer = Tracer()
+    span = tracer.start_active_span()
+    assert span.wrapped is not None
+
+    span.set_operation_name('a')
+    span.set_baggage_item('key1', 'value1')
+    span.get_baggage_item('key1')
+    span.log_kv({})
+    span.log_event('event1')
+
+
+def test_capture():
+    tracer = Tracer()
+    span = tracer.start_active_span()
+    continuation = span.capture()
+    assert continuation is not None
+    assert continuation.activate() is not None

--- a/tests/test_threadlocalactivesource.py
+++ b/tests/test_threadlocalactivesource.py
@@ -1,0 +1,85 @@
+import mock
+from opentracing import Span
+from opentracing.ext.threadlocalspansource import ThreadLocalActiveSpanSource
+
+
+def test_make_active():
+    source = ThreadLocalActiveSpanSource()
+    span = Span(None, None)
+    active_span = source.make_active(span)
+    assert active_span == source.active_span
+    assert active_span.wrapped == span
+
+
+def test_deactivate():
+    source = ThreadLocalActiveSpanSource()
+    span = Span(None, None)
+
+    with mock.patch.object(span, 'finish') as finish:
+        active_span = source.make_active(span)
+        active_span.deactivate()
+        assert finish.call_count == 1
+        assert source.active_span is None
+
+
+def test_context():
+    source = ThreadLocalActiveSpanSource()
+    span = Span(None, None)
+
+    with mock.patch.object(span, 'finish') as finish:
+        with mock.patch.object(span, 'log_kv') as log_kv:
+            with source.make_active(span):
+                pass
+
+            assert finish.call_count == 1
+            assert log_kv.call_count == 0
+            assert source.active_span is None
+
+
+def test_context_error():
+    source = ThreadLocalActiveSpanSource()
+    span = Span(None, None)
+
+    with mock.patch.object(span, 'finish') as finish:
+        with mock.patch.object(span, 'log_kv') as log_kv:
+
+            try:
+                with source.make_active(span):
+                    raise ValueError()
+            except ValueError:
+                pass
+
+            assert finish.call_count == 1
+            assert log_kv.call_count == 1
+            assert source.active_span is None
+
+
+def test_capture():
+    source = ThreadLocalActiveSpanSource()
+    span = Span(None, None)
+
+    with mock.patch.object(span, 'finish') as finish:
+        active_span = source.make_active(span)
+        continuation = active_span.capture()
+        active_span.deactivate()
+
+        assert finish.call_count == 0
+        assert source.active_span is None
+
+        active_span2 = continuation.activate()
+        assert finish.call_count == 0
+        assert source.active_span == active_span2
+
+        active_span2.deactivate()
+        assert finish.call_count == 1
+        assert source.active_span is None
+
+
+def test_wrong_order():
+    source = ThreadLocalActiveSpanSource()
+    span1 = source.make_active(Span(None, None))
+    span2 = source.make_active(Span(None, None))
+    assert span2 == source.active_span
+
+    span1.deactivate()
+    assert span2 == source.active_span


### PR DESCRIPTION
This is based on the recent ActiveSpanSource work in the Java repo (115 PR). Notes on this take:

1. BaseSpan kept the former Span calls, minus the tracer property and context manager methods. Span implements `finish()`, the respective actual context manager methods, and `context` and `tracer` properties. ActiveSpan implements `deactivate()`, the respective actual context manager methods, and `wrapper` property, for the wrapped Span.

2. ActiveSpanContinuation remained as its own class, not within the ActiveSpan class - inner classes, public-wise, are not as used in Python.

3. Added `start_active_span()` method only, while keeping the `start_span()` around without deprecating it, so that it the latter will keep its previous, ‘manual’ behaviour. As the Python API does not use a Builder approach, and uses a few optional parameters on these methods, it *felt* like it would be overdoing by providing three methods for the start span logic (the two new ones, and the existing, deprecated one).  Feedback on this?

4. Ignore active span parameter for the start() methods - should it default to False? Or to None, as the other optional methods do, and let the implementers decide?

5. Included a thread-local implementation as a way of sample/testing the current approach.

Any feedback or suggestion is welcome. Open to questions or any discussion.