### PR TITLE
ActiveSpanSource for in-process context propagation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Somewhere in your server's request handler code:
            format=Format.HTTP_HEADERS,
            carrier=request.headers,
        )
-       span = tracer.start_span(
+       span = tracer.start_manual_span(
            operation_name=request.operation,
            child_of(span_context))
        span.set_tag('http.url', request.full_url)
@@ -107,7 +107,7 @@ Somewhere in your service that's about to make an outgoing call:
    def before_http_request(request, current_span_extractor):
        op = request.operation
        parent_span = current_span_extractor()
-       outbound_span = opentracing.tracer.start_span(
+       outbound_span = opentracing.tracer.start_manual_span(
            operation_name=op,
            parent=parent_span
        )
@@ -127,7 +127,7 @@ Somewhere in your service that's about to make an outgoing call:
            span=outbound_span,
            format=Format.HTTP_HEADERS,
            carrier=http_header_carrier)
-           
+
        for key, value in http_header_carrier.iteritems():
            request.add_header(key, value)
 

--- a/opentracing/active_span_source.py
+++ b/opentracing/active_span_source.py
@@ -36,20 +36,10 @@ class BaseActiveSpanSource(object):
         """
         raise NotImplementedError
 
-    def get_active_span(self):
+    def get_active(self):
         """Returns the `Span` that is currently activated for this source.
 
         :return: the current active `Span`
-        """
-        raise NotImplementedError
-
-    def deactivate(self, span):
-        """Deactivate the given `Span`, restoring the previous active one.
-        This method must take in consideration that a `Span` may be deactivated
-        when it's not really active. In that case, the current active stack
-        must not be changed.
-
-        :param span: the `Span` that must be deactivated
         """
         raise NotImplementedError
 
@@ -62,8 +52,5 @@ class NoopActiveSpanSource(BaseActiveSpanSource):
     def make_active(self, span):
         pass
 
-    def get_active_span(self):
-        pass
-
-    def deactivate(self, span):
+    def get_active(self):
         pass

--- a/opentracing/active_span_source.py
+++ b/opentracing/active_span_source.py
@@ -21,8 +21,8 @@
 from __future__ import absolute_import
 
 
-class BaseActiveSpanSource(object):
-    """BaseActiveSpanSource is the interface for a pluggable class that
+class ActiveSpanSource(object):
+    """ActiveSpanSource is the interface for a pluggable class that
     keeps track of the current active `Span`. It must be used as a
     base class in specific implementations.
     """
@@ -34,23 +34,11 @@ class BaseActiveSpanSource(object):
 
         :param span: the `Span` that is marked as active.
         """
-        raise NotImplementedError
+        pass
 
     def get_active(self):
         """Returns the `Span` that is currently activated for this source.
 
         :return: the current active `Span`
         """
-        raise NotImplementedError
-
-
-class NoopActiveSpanSource(BaseActiveSpanSource):
-    """NoopActiveSpanSource provides the logic to get and set the current
-    active `Span`. This is a cheap noop implementation that is used when
-    a specific `Tracer` implementation is not used.
-    """
-    def make_active(self, span):
-        pass
-
-    def get_active(self):
         pass

--- a/opentracing/active_span_source.py
+++ b/opentracing/active_span_source.py
@@ -19,8 +19,6 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-from .span import Span
-from .span import SpanContext
 
 
 class BaseActiveSpanSource(object):
@@ -38,8 +36,7 @@ class BaseActiveSpanSource(object):
         """
         raise NotImplementedError
 
-    @property
-    def active_span(self):
+    def get_active_span(self):
         """Returns the `Span` that is currently activated for this source.
 
         :return: the current active `Span`
@@ -62,16 +59,11 @@ class NoopActiveSpanSource(BaseActiveSpanSource):
     active `Span`. This is a cheap noop implementation that is used when
     a specific `Tracer` implementation is not used.
     """
-    def __init__(self):
-        self._noop_span_context = SpanContext()
-        self._noop_span = Span(None, context=self._noop_span_context)
-
     def make_active(self, span):
         pass
 
-    @property
-    def active_span(self):
-        return self._noop_span
+    def get_active_span(self):
+        pass
 
     def deactivate(self, span):
         pass

--- a/opentracing/active_span_source.py
+++ b/opentracing/active_span_source.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+from .span import Span
+from .span import SpanContext
+
+
+class BaseActiveSpanSource(object):
+    """BaseActiveSpanSource is the interface for a pluggable class that
+    keeps track of the current active `Span`. It must be used as a
+    base class in specific implementations.
+    """
+    def make_active(self, span):
+        """Sets the given `Span` as active, so that it is used as a parent
+        when creating new spans. The implementation must keep track of the
+        active spans sequence, so that previous spans can be resumed
+        after a deactivation.
+
+        :param span: the `Span` that is marked as active.
+        """
+        raise NotImplementedError
+
+    @property
+    def active_span(self):
+        """Returns the `Span` that is currently activated for this source.
+
+        :return: the current active `Span`
+        """
+        raise NotImplementedError
+
+    def deactivate(self, span):
+        """Deactivate the given `Span`, restoring the previous active one.
+        This method must take in consideration that a `Span` may be deactivated
+        when it's not really active. In that case, the current active stack
+        must not be changed.
+
+        :param span: the `Span` that must be deactivated
+        """
+        raise NotImplementedError
+
+
+class NoopActiveSpanSource(BaseActiveSpanSource):
+    """NoopActiveSpanSource provides the logic to get and set the current
+    active `Span`. This is a cheap noop implementation that is used when
+    a specific `Tracer` implementation is not used.
+    """
+    def __init__(self):
+        self._noop_span_context = SpanContext()
+        self._noop_span = Span(None, context=self._noop_span_context)
+
+    def make_active(self, span):
+        pass
+
+    @property
+    def active_span(self):
+        return self._noop_span
+
+    def deactivate(self, span):
+        pass

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -44,25 +44,26 @@ class APICompatibilityCheckMixin(object):
         """
         return True
 
-    def test_start_span(self):
+    def test_start_manual_span(self):
         tracer = self.tracer()
-        span = tracer.start_span(operation_name='Fry')
+        span = tracer.start_manual_span(operation_name='Fry')
         span.finish()
-        with tracer.start_span(operation_name='Fry',
-                               tags={'birthday': 'August 14 1974'}) as span:
+        with tracer.start_manual_span(
+                operation_name='Fry',
+                tags={'birthday': 'August 14 1974'}) as span:
             span.log_event('birthplace',
                            payload={'hospital': 'Brooklyn Pre-Med Hospital',
                                     'city': 'Old New York'})
 
-    def test_start_span_with_parent(self):
+    def test_start_manual_span_with_parent(self):
         tracer = self.tracer()
-        parent_span = tracer.start_span(operation_name='parent')
+        parent_span = tracer.start_manual_span(operation_name='parent')
         assert parent_span is not None
-        span = tracer.start_span(
+        span = tracer.start_manual_span(
             operation_name='Leela',
             child_of=parent_span)
         span.finish()
-        span = tracer.start_span(
+        span = tracer.start_manual_span(
             operation_name='Leela',
             references=[opentracing.follows_from(parent_span.context)],
             tags={'birthplace': 'sewers'})
@@ -71,7 +72,7 @@ class APICompatibilityCheckMixin(object):
 
     def test_start_child_span(self):
         tracer = self.tracer()
-        parent_span = tracer.start_span(operation_name='parent')
+        parent_span = tracer.start_manual_span(operation_name='parent')
         assert parent_span is not None
         child_span = opentracing.start_child_span(
             parent_span, operation_name='Leela')
@@ -79,23 +80,25 @@ class APICompatibilityCheckMixin(object):
         parent_span.finish()
 
     def test_set_operation_name(self):
-        span = self.tracer().start_span().set_operation_name('Farnsworth')
+        span = self.tracer().start_manual_span()
+        span.set_operation_name('Farnsworth')
         span.finish()
 
     def test_span_as_context_manager(self):
+        tracer = self.tracer()
         finish = {'called': False}
 
         def mock_finish(*_):
             finish['called'] = True
 
-        with self.tracer().start_span(operation_name='antiquing') as span:
+        with tracer.start_manual_span(operation_name='antiquing') as span:
             setattr(span, 'finish', mock_finish)
         assert finish['called'] is True
 
         # now try with exception
         finish['called'] = False
         try:
-            with self.tracer().start_span(operation_name='antiquing') as span:
+            with tracer.start_manual_span(operation_name='antiquing') as span:
                 setattr(span, 'finish', mock_finish)
                 raise ValueError()
         except ValueError:
@@ -104,14 +107,15 @@ class APICompatibilityCheckMixin(object):
             raise AssertionError('Expected ValueError')  # pragma: no cover
 
     def test_span_tag_value_types(self):
-        with self.tracer().start_span(operation_name='ManyTypes') as span:
+        tracer = self.tracer()
+        with tracer.start_manual_span(operation_name='ManyTypes') as span:
             span. \
                 set_tag('an_int', 9). \
                 set_tag('a_bool', True). \
                 set_tag('a_string', 'aoeuidhtns')
 
     def test_span_tags_with_chaining(self):
-        span = self.tracer().start_span(operation_name='Farnsworth')
+        span = self.tracer().start_manual_span(operation_name='Farnsworth')
         span. \
             set_tag('birthday', '9 April, 2841'). \
             set_tag('loves', 'different lengths of wires')
@@ -121,7 +125,7 @@ class APICompatibilityCheckMixin(object):
         span.finish()
 
     def test_span_logs(self):
-        span = self.tracer().start_span(operation_name='Fry')
+        span = self.tracer().start_manual_span(operation_name='Fry')
 
         # Newer API
         span.log_kv(
@@ -146,7 +150,7 @@ class APICompatibilityCheckMixin(object):
                 payload={'year': 2999})
 
     def test_span_baggage(self):
-        with self.tracer().start_span(operation_name='Fry') as span:
+        with self.tracer().start_manual_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span_ref = span.set_baggage_item('Kiff-loves', 'Amy')
             assert span_ref is span
@@ -156,7 +160,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_context_baggage(self):
-        with self.tracer().start_span(operation_name='Fry') as span:
+        with self.tracer().start_manual_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span.set_baggage_item('Kiff-loves', 'Amy')
             if self.check_baggage_values():
@@ -164,7 +168,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_text_propagation(self):
-        with self.tracer().start_span(operation_name='Bender') as span:
+        with self.tracer().start_manual_span(operation_name='Bender') as span:
             text_carrier = {}
             self.tracer().inject(
                 span_context=span.context,
@@ -176,7 +180,7 @@ class APICompatibilityCheckMixin(object):
             assert extracted_ctx.baggage == {}
 
     def test_binary_propagation(self):
-        with self.tracer().start_span(operation_name='Bender') as span:
+        with self.tracer().start_manual_span(operation_name='Bender') as span:
             bin_carrier = bytearray()
             self.tracer().inject(
                 span_context=span.context,
@@ -193,7 +197,7 @@ class APICompatibilityCheckMixin(object):
             (Format.HTTP_HEADERS, {}),
             (Format.BINARY, bytearray()),
         ]
-        with self.tracer().start_span(operation_name='Bender') as span:
+        with self.tracer().start_manual_span(operation_name='Bender') as span:
             for fmt, carrier in formats:
                 # expecting no exceptions
                 span.tracer.inject(span.context, fmt, carrier)
@@ -201,7 +205,7 @@ class APICompatibilityCheckMixin(object):
 
     def test_unknown_format(self):
         custom_format = 'kiss my shiny metal ...'
-        with self.tracer().start_span(operation_name='Bender') as span:
+        with self.tracer().start_manual_span(operation_name='Bender') as span:
             with pytest.raises(opentracing.UnsupportedFormatException):
                 span.tracer.inject(span.context, custom_format, {})
             with pytest.raises(opentracing.UnsupportedFormatException):

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 The OpenTracing Authors.
+# Copyright (c) 2016-2017 The OpenTracing Authors.
 #
 # Copyright (c) 2015 Uber Technologies, Inc.
 #
@@ -232,16 +232,16 @@ class ContinuationMixin(object):
     propagation.
 
     If the application needs to defer work that should be part of the same
-    `Span`, the `ContinuationMixin` provides a `capture` method that adds a
-    marker to the span so that it can be deactivated without finishing. In
-    another asynchronous executor and/or thread, it can be activated again.
+    `Span`, the `ContinuationMixin` provides a `capture` method that increments
+    a counter to the span so that it can be deactivated without finishing. In
+    another asynchronous executor and/or thread, it can be resumed.
     """
     def capture(self):
         """
         Capture the `Span` tracing session as well as any 3rd-party execution
         context of interest. After calling this method, the `Span` may be used
         later in a closure or callback function where it may be resumed and
-        reactivated using the tracer `ActiveSpanSource.make_active()`.
+        reactivated using the tracer `active_span_source.make_active()`.
 
         IMPORTANT: the caller MUST activate and then deactivate the `Span`
         otherwise it will never automatically finish. That is, calling

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -203,7 +203,7 @@ class BaseSpan(object):
                 'python.exception.val': exc_val,
                 'python.exception.tb': exc_tb,
                 })
-        self.finish()
+        self.deactivate()
 
     def log_event(self, event, payload=None):
         """DEPRECATED"""
@@ -259,7 +259,7 @@ class ContinuationMixin(object):
         NOTE: Calling `deactivate()` more than once on a single `Span` instance
         leads to undefined behavior.
         """
-        pass
+        self.finish()
 
 
 class Span(ContinuationMixin, BaseSpan):

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -25,6 +25,7 @@ from collections import namedtuple
 from .span import Span
 from .span import SpanContext
 from .propagation import Format, UnsupportedFormatException
+from .active_span_source import NoopActiveSpanSource
 
 
 class Tracer(object):
@@ -40,31 +41,84 @@ class Tracer(object):
     def __init__(self):
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
+        self._active_span_source = NoopActiveSpanSource()
 
-    def start_span(self,
-                   operation_name=None,
-                   child_of=None,
-                   references=None,
-                   tags=None,
-                   start_time=None):
+    @property
+    def active_span_source(self):
+        return self._active_span_source
+
+    @property
+    def active_span(self):
+        return self._active_span_source.active_span
+
+    def start_active_span(self, operation_name, tags=None, start_time=None):
+        """Starts and returns a new `Span` representing a unit of work. This
+        method differs from `start_manual_span` because it uses in-process
+        context propagation to keep track of the current active `Span` (if
+        available).
+
+        Starting a root `Span` with no casual references and a child `Span`
+        in a different function, is possible without passing the parent
+        reference around::
+
+            def handle_request(request):
+                root_span = tracer.start_active_span('request.handler')
+                data = get_data(request)
+
+            def get_data(request):
+                # child_span has `root_span` as a parent
+                child_span = tracer.start_active_span('db.query')
+
+
+        :param operation_name: name of the operation represented by the new
+            span from the perspective of the current service.
+        :param tags: an optional dictionary of Span Tags. The caller gives up
+            ownership of that dictionary, because the Tracer may use it as-is
+            to avoid extra data copying.
+        :param start_time: an explicit Span start time as a unix timestamp per
+            time.time()
+
+        :return: Returns an already-started `Span` instance, marked as active.
+        """
+        # use an ActiveSpanSource to retrieve the current Span
+        parent_span = self.active_span
+
+        # create a new root Span or a child if a parent is available
+        span = self.start_manual_span(
+            operation_name=operation_name,
+            child_of=parent_span,
+            tags=tags,
+            start_time=start_time,
+        )
+
+        # set Span as active
+        self.active_span_source.make_active(span)
+        return span
+
+    def start_manual_span(self,
+                          operation_name=None,
+                          child_of=None,
+                          references=None,
+                          tags=None,
+                          start_time=None):
         """Starts and returns a new Span representing a unit of work.
 
 
         Starting a root Span (a Span with no causal references)::
 
-            tracer.start_span('...')
+            tracer.start_manual_span('...')
 
 
         Starting a child Span (see also start_child_span())::
 
-            tracer.start_span(
+            tracer.start_manual_span(
                 '...',
                 child_of=parent_span)
 
 
         Starting a child Span in a more verbose way::
 
-            tracer.start_span(
+            tracer.start_manual_span(
                 '...',
                 references=[opentracing.child_of(parent_span)])
 
@@ -150,8 +204,8 @@ class ReferenceType(object):
 class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     """A Reference pairs a reference type with a referenced SpanContext.
 
-    References are used by Tracer.start_span() to describe the relationships
-    between Spans.
+    References are used by Tracer.start_manual_span() to describe the
+    relationships between Spans.
 
     Tracer implementations must ignore references where referenced_context is
     None.  This behavior allows for simpler code when an inbound RPC request
@@ -159,7 +213,7 @@ class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     None::
 
         parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
-        span = tracer.start_span(
+        span = tracer.start_manual_span(
             'operation', references=child_of(parent_ref)
         )
 
@@ -175,7 +229,8 @@ def child_of(referenced_context=None):
         If None is passed, this reference must be ignored by the tracer.
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_span(..., references=...)
+    :return: A Reference suitable for
+        Tracer.start_manual_span(..., references=...)
     """
     return Reference(
         type=ReferenceType.CHILD_OF,
@@ -189,7 +244,8 @@ def follows_from(referenced_context=None):
         If None is passed, this reference must be ignored by the tracer.
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_span(..., references=...)
+    :return: A Reference suitable for
+        Tracer.start_manual_span(..., references=...)
     """
     return Reference(
         type=ReferenceType.FOLLOWS_FROM,
@@ -201,7 +257,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
 
     Equivalent to calling
 
-        parent_span.tracer().start_span(
+        parent_span.tracer().start_manual_span(
             operation_name,
             references=opentracing.child_of(parent_span.context),
             tags=tags,
@@ -218,7 +274,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
 
     :return: Returns an already-started Span instance.
     """
-    return parent_span.tracer.start_span(
+    return parent_span.tracer.start_manual_span(
         operation_name=operation_name,
         child_of=parent_span,
         tags=tags,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 The OpenTracing Authors.
+# Copyright (c) 2016-2017 The OpenTracing Authors.
 #
 # Copyright (c) 2015 Uber Technologies, Inc.
 #
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import
 from collections import namedtuple
+import warnings
+
 from .span import Span
 from .span import SpanContext
 from .propagation import Format, UnsupportedFormatException
@@ -71,7 +73,7 @@ class Tracer(object):
                     data = get_data(request)
 
             def get_data(request):
-                # child_span has `root_span` as a parent
+                # `db.query` is child of `request.handler`
                 with tracer.start_active_span('db.query'):
                     # get some data ...
 
@@ -158,6 +160,28 @@ class Tracer(object):
         :return: Returns an already-started Span instance.
         """
         return self._noop_span
+
+    def start_span(self,
+                   operation_name=None,
+                   child_of=None,
+                   references=None,
+                   tags=None,
+                   start_time=None):
+        """DEPRECATED: this method is part of the previous API and must
+        not be used. Use `start_active_span()` or `start_manual_span()`
+        instead.
+        """
+        # TODO: print the WARNING only once otherwise it will flood
+        # users' logs. `warnings.simplefilter` helps on that.
+        warnings.warn('Deprecated!', DeprecationWarning, stacklevel=2)
+        return self.start_manual_span(
+            operation_name=operation_name,
+            child_of=child_of,
+            references=references,
+            tags=tags,
+            start_time=start_time,
+            ignore_active_span=True,
+        )
 
     def inject(self, span_context, format, carrier):
         """Injects `span_context` into `carrier`.

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 from .span import Span
 from .span import SpanContext
 from .propagation import Format, UnsupportedFormatException
-from .active_span_source import NoopActiveSpanSource
+from .active_span_source import ActiveSpanSource
 
 
 class Tracer(object):
@@ -41,7 +41,7 @@ class Tracer(object):
     def __init__(self):
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
-        self._active_span_source = NoopActiveSpanSource()
+        self._active_span_source = ActiveSpanSource()
 
     @property
     def active_span_source(self):

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -49,7 +49,7 @@ class Tracer(object):
 
     @property
     def active_span(self):
-        return self._active_span_source.active_span
+        return self._active_span_source.get_active_span()
 
     def start_active_span(self, operation_name, tags=None, start_time=None):
         """Starts and returns a new `Span` representing a unit of work. This
@@ -81,18 +81,18 @@ class Tracer(object):
         :return: Returns an already-started `Span` instance, marked as active.
         """
         # use an ActiveSpanSource to retrieve the current Span
-        parent_span = self.active_span
+        active_span = self._active_span_source.get_active_span()
 
         # create a new root Span or a child if a parent is available
         span = self.start_manual_span(
             operation_name=operation_name,
-            child_of=parent_span,
+            child_of=active_span,
             tags=tags,
             start_time=start_time,
         )
 
         # set Span as active
-        self.active_span_source.make_active(span)
+        self._active_span_source.make_active(span)
         return span
 
     def start_manual_span(self,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -96,20 +96,7 @@ class Tracer(object):
 
         :return: Returns an already-started `Span` instance, marked as active.
         """
-        # create a new Span considering the current active `Span` or the
-        # provided references
-        span = self.start_manual_span(
-            operation_name=operation_name,
-            child_of=child_of,
-            references=references,
-            tags=tags,
-            start_time=start_time,
-            ignore_active_span=ignore_active_span,
-        )
-
-        # set the Span as active
-        self._active_span_source.make_active(span)
-        return span
+        return self._noop_span
 
     def start_manual_span(self,
                           operation_name=None,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -49,7 +49,7 @@ class Tracer(object):
 
     @property
     def active_span(self):
-        return self._active_span_source.get_active_span()
+        return self._active_span_source.get_active()
 
     def start_active_span(self,
                           operation_name=None,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -56,7 +56,8 @@ class Tracer(object):
                           child_of=None,
                           references=None,
                           tags=None,
-                          start_time=None):
+                          start_time=None,
+                          ignore_active_span=False):
         """Starts and returns a new `Span` representing a unit of work. This
         method uses in-process context propagation to keep track of the current
         active `Span`, if available and if no references are provided.
@@ -88,6 +89,8 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
+        :param ignore_active_span: an explicit flag that ignores the current
+            active `Span` and creates a root `Span`.
 
         :return: Returns an already-started `Span` instance, marked as active.
         """
@@ -99,6 +102,7 @@ class Tracer(object):
             references=references,
             tags=tags,
             start_time=start_time,
+            ignore_active_span=ignore_active_span,
         )
 
         # set the Span as active
@@ -110,7 +114,8 @@ class Tracer(object):
                           child_of=None,
                           references=None,
                           tags=None,
-                          start_time=None):
+                          start_time=None,
+                          ignore_active_span=False):
         """Starts and returns a new Span representing a unit of work. This
         method uses in-process context propagation to keep track of the current
         active `Span`, if available and if no references are provided.
@@ -147,6 +152,8 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
+        :param ignore_active_span: an explicit flag that ignores the current
+            active `Span` and creates a root `Span`.
 
         :return: Returns an already-started Span instance.
         """

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -31,8 +31,9 @@ from opentracing.ext import tags
 
 def test_span():
     tracer = Tracer()
-    parent = tracer.start_span('parent')
-    child = tracer.start_span('test', references=child_of(parent.context))
+    parent = tracer.start_manual_span('parent')
+    child = tracer.start_manual_span('test',
+                                     references=child_of(parent.context))
     assert parent == child
     child.log_kv({'event': 'cache_hit', 'size.bytes': 42})
     child.log_kv({'event': 'cache_miss'}, time.time())
@@ -68,7 +69,7 @@ def test_span():
 
 def test_inject():
     tracer = Tracer()
-    span = tracer.start_span()
+    span = tracer.start_manual_span()
 
     bin_carrier = bytearray()
     tracer.inject(

--- a/tests/test_noop_tracer.py
+++ b/tests/test_noop_tracer.py
@@ -27,7 +27,7 @@ from opentracing import Tracer
 
 def test_tracer():
     tracer = Tracer()
-    span = tracer.start_span(operation_name='root')
-    child = tracer.start_span(operation_name='child',
-                              references=child_of(span))
+    span = tracer.start_manual_span(operation_name='root')
+    child = tracer.start_manual_span(operation_name='child',
+                                     references=child_of(span))
     assert span == child


### PR DESCRIPTION
### Overview

This PR aims to solve in-process context propagation for Python. It has three aims:

- adding a simple, high level API that allows very simple tracing that will handle 90% of use cases
- a low-level API that allows more control for tracing complex async operations
- a pluggable interface that allows tracing async operations with all the common frameworks - threads, asyncio, tornado, etc

Implementation details may be discussed here: https://github.com/opentracing/basictracer-python/pull/23

We'd like to keep two types of feedback separate - nomenclature vs structural. If everybody agrees on the structure / semantics of the PR, then we can debate naming and nomenclature. Cool?

### Details

The main idea is having one or more specific `ActiveSpanSource` implementations that keeps track of the current active `Span` so that the high-level API provides:

```python
with tracer.start_active_span("web.request") as span:
    span.set_tag("url", "/home")
    data = get_data()

    with tracer.start_active_span("template.render"):
        return "%s" % (data)
```

When more control is needed, we can interact with the current active `Span` stack, see examples below:
* Propagation when callbacks are used ([link][8])
* Fake server implementation that executes asynchronous jobs ([link][1])
* Propagation between different threads ([link][2])
* Propagation in `asyncio` ([link][3])
* Propagation in `gevent` ([link][4])
* Propagation in Tornado using a `StackContext` ([link][5])

Note: we might want to include these in an official OT library or helper module at some point ---^

This API is flexible when handling some edge cases that could happen in simple or complex applications. Currently, `asyncio`, `gevent`, Tornado and threading are supported with [specific implementations][6] and with some [helpers][7] that may become part of some `opentracing-contrib-*` package.

### Nomenclature Questions

- this assumes that we want to leave `start_span` untouched. In an ideal world, I think `start_active_span` should be the method used 99% of the time, so we should consider using something shorter / cleaner here like `start_span`, `span` or `trace`. 

What's missing and that will be completed after an initial review:
* [ ] tests for the `ActiveSpanSource` API
* [x] `start_span` must be a `@deprecated` function (at the moment it has been fully replaced by `start_manual_span(...)`. or can we use `start_span` all the time?
* [ ] instrument a real complex application before merging
* [ ] update the documentation providing both manual and automatic propagation

[1]: https://github.com/palazzem/ot-examples/blob/master/examples/server.py
[2]: https://github.com/palazzem/ot-examples/blob/master/examples/threads.py
[3]: https://github.com/palazzem/ot-examples/blob/master/examples/asyncio.py
[4]: https://github.com/palazzem/ot-examples/blob/master/examples/gevent.py
[5]: https://github.com/palazzem/ot-examples/blob/master/examples/tornado.py
[6]: https://github.com/palazzem/ot-examples/blob/master/ext/active_span_source.py
[7]: https://github.com/palazzem/ot-examples/blob/master/ext/helpers.py
[8]: https://gist.github.com/palazzem/270648ac5e15dc2b71de54f8e941b4ba