### PR TITLE
New line after `code-block` so RST can render properly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,7 @@ Outbound request
 Somewhere in your service that's about to make an outgoing call:
 
 .. code-block:: python
+
    from opentracing.ext import tags
    from opentracing.propagation import Format
    from opentracing_instrumentation import request_context


### PR DESCRIPTION
Sorry for spamming... this *should* fix the README rst code block.