### PR TITLE
Remove 'futures' from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'futures',
-    ],
     extras_require={
         'tests': [
             'doubles',


### PR DESCRIPTION
The source code doesn't use anything provided by the 'futures' module.

Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>