### PR TITLE
Implement ScopeManager for in-process propagation

### DIFF
--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -22,6 +22,8 @@
 from __future__ import absolute_import
 from .span import Span  # noqa
 from .span import SpanContext  # noqa
+from .scope import Scope  # noqa
+from .scope_manager import ScopeManager  # noqa
 from .tracer import child_of  # noqa
 from .tracer import follows_from  # noqa
 from .tracer import Reference  # noqa

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -47,21 +47,21 @@ class APICompatibilityCheckMixin(object):
 
     def check_scope_manager(self):
         """If true, the test suite will validate the `ScopeManager` propagation
-        and storage to ensure the correct parenting and active `Scope` are
-        properly defined by the implementation. If false, it will only use
-        the API without any assert. The latter mode is only useful for no-op
-        tracer.
+        to ensure correct parenting. If false, it will only use the API without
+        asserting. The latter mode is only useful for no-op tracer.
         """
         return True
 
     def is_parent(self, parent, span):
         """Utility method that must be defined by Tracer implementers to define
         how the test suite can check when a `Span` is a parent of another one.
+        It depends by the underlying implementation that is not part of the
+        OpenTracing API.
         """
         return False
 
     def test_start_span(self):
-        # test for deprecated API
+        # test deprecated API for minor compatibility
         tracer = self.tracer()
         span = tracer.start_span(operation_name='Fry')
         span.finish()
@@ -320,7 +320,7 @@ class APICompatibilityCheckMixin(object):
         # when a Scope is closed, the previous one must be activated
         tracer = self.tracer()
         with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Fry'):
+            with tracer.start_active(operation_name='Farnsworth'):
                 pass
 
             if self.check_scope_manager():
@@ -335,7 +335,7 @@ class APICompatibilityCheckMixin(object):
         parent = tracer.start_active(operation_name='Fry',
                                      finish_on_close=False)
         with mock.patch.object(parent.span(), 'finish') as finish:
-            with tracer.start_active(operation_name='Fry'):
+            with tracer.start_active(operation_name='Farnsworth'):
                 pass
             parent.close()
 
@@ -348,7 +348,7 @@ class APICompatibilityCheckMixin(object):
         # only the active `Scope` can be closed
         tracer = self.tracer()
         parent = tracer.start_active(operation_name='Fry')
-        child = tracer.start_active(operation_name='Fry')
+        child = tracer.start_active(operation_name='Farnsworth')
         parent.close()
 
         if self.check_scope_manager():

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+
+class Scope(object):
+    """
+    A `Scope` formalizes the activation and deactivation of a `Span`, usually
+    from a CPU standpoint. Many times a `Span` will be extant (in that
+    `Span#finish()` has not been called) despite being in a non-runnable state
+    from a CPU/scheduler standpoint. For instance, a `Span` representing the
+    client side of an RPC will be unfinished but blocked on IO while the RPC is
+    still outstanding. A `Scope` defines when a given `Span` is scheduled
+    and on the path.
+    """
+    def __init__(self, span):
+        """
+        Initialize a `Scope` for the given `Span` object
+
+        :param span: the `Span` used for this `Scope`
+        """
+        # TODO: maybe it should always be the NoopSpan?
+        # something similar to:
+        # self._noop_span_context = SpanContext()
+        # self._noop_span = Span(tracer=self, context=self._noop_span_context)
+        self._span = span
+
+    def span(self):
+        """
+        Return the `Span` that's been scoped by this `Scope`.
+        """
+        return self._span
+
+    def close(self):
+        """
+        Mark the end of the active period for the current thread and `Scope`,
+        updating the `ScopeManager#active()` in the process.
+
+        NOTE: Calling `close()` more than once on a single `Scope` instance
+        leads to undefined behavior.
+        """
+        pass
+
+    def __enter__(self):
+        """
+        Allow `Scope` to be used inside a Python Context Manager.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Call `close()` when the execution is outside the Python
+        Context Manager.
+        """
+        self.close()

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -31,16 +31,14 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, span):
+    def __init__(self, span, finish_span_on_close=True):
         """
         Initialize a `Scope` for the given `Span` object
 
         :param span: the `Span` used for this `Scope`
+        :param finish_span_on_close: whether span should automatically be
+            finished when `Scope#close()` is called
         """
-        # TODO: maybe it should always be the NoopSpan?
-        # something similar to:
-        # self._noop_span_context = SpanContext()
-        # self._noop_span = Span(tracer=self, context=self._noop_span_context)
         self._span = span
 
     def span(self):

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -31,14 +31,15 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, span, finish_span_on_close=True):
+    def __init__(self, manager, span, finish_on_close=True):
         """
         Initialize a `Scope` for the given `Span` object
 
         :param span: the `Span` used for this `Scope`
-        :param finish_span_on_close: whether span should automatically be
+        :param finish_on_close: whether span should automatically be
             finished when `Scope#close()` is called
         """
+        self._manager = manager
         self._span = span
 
     def span(self):

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -22,9 +22,8 @@ from __future__ import absolute_import
 
 
 class Scope(object):
-    """
-    A `Scope` formalizes the activation and deactivation of a `Span`, usually
-    from a CPU standpoint. Many times a `Span` will be extant (in that
+    """A `Scope` formalizes the activation and deactivation of a `Span`,
+    usually from a CPU standpoint. Many times a `Span` will be extant (in that
     `Span#finish()` has not been called) despite being in a non-runnable state
     from a CPU/scheduler standpoint. For instance, a `Span` representing the
     client side of an RPC will be unfinished but blocked on IO while the RPC is
@@ -32,9 +31,9 @@ class Scope(object):
     and on the path.
     """
     def __init__(self, manager, span, finish_on_close=True):
-        """
-        Initialize a `Scope` for the given `Span` object
+        """Initialize a `Scope` for the given `Span` object
 
+        :param manager: the `ScopeManager` that created this `Scope`
         :param span: the `Span` used for this `Scope`
         :param finish_on_close: whether span should automatically be
             finished when `Scope#close()` is called
@@ -43,14 +42,11 @@ class Scope(object):
         self._span = span
 
     def span(self):
-        """
-        Return the `Span` that's been scoped by this `Scope`.
-        """
+        """Return the `Span` that's been scoped by this `Scope`."""
         return self._span
 
     def close(self):
-        """
-        Mark the end of the active period for the current thread and `Scope`,
+        """Mark the end of the active period for the current thread and `Scope`,
         updating the `ScopeManager#active()` in the process.
 
         NOTE: Calling `close()` more than once on a single `Scope` instance
@@ -59,14 +55,11 @@ class Scope(object):
         pass
 
     def __enter__(self):
-        """
-        Allow `Scope` to be used inside a Python Context Manager.
-        """
+        """Allow `Scope` to be used inside a Python Context Manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Call `close()` when the execution is outside the Python
+        """Call `close()` when the execution is outside the Python
         Context Manager.
         """
         self.close()

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -31,7 +31,9 @@ class ScopeManager(object):
     `Span` / `Scope` (via `ScopeManager#active()`).
     """
     def __init__(self):
-        # TODO: check that if it's required
+        # TODO: `tracer` should not be None, but we don't have a reference;
+        # should we move the NOOP SpanContext, Span, Scope to somewhere
+        # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
         self._noop_scope = Scope(self._noop_span)
 

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -20,8 +20,8 @@
 
 from __future__ import absolute_import
 
-from opentracing.scope import Scope
-from opentracing.span import Span, SpanContext
+from .span import Span, SpanContext
+from .scope import Scope
 
 
 class ScopeManager(object):

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -25,8 +25,7 @@ from .scope import Scope
 
 
 class ScopeManager(object):
-    """
-    The `ScopeManager` interface abstracts both the activation of `Span`
+    """The `ScopeManager` interface abstracts both the activation of `Span`
     instances (via `ScopeManager#activate(Span)`) and access to an active
     `Span` / `Scope` (via `ScopeManager#active()`).
     """
@@ -38,8 +37,7 @@ class ScopeManager(object):
         self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close=True):
-        """
-        Make a `Span` instance active.
+        """Make a `Span` instance active.
 
         :param span: the `Span` that should become active
         :param finish_on_close: whether span should automatically be
@@ -52,8 +50,7 @@ class ScopeManager(object):
         return self._noop_scope
 
     def active(self):
-        """
-        Return the currently active `Scope` which can be used to access the
+        """Return the currently active `Scope` which can be used to access the
         currently active `Scope#span()`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -35,14 +35,14 @@ class ScopeManager(object):
         # should we move the NOOP SpanContext, Span, Scope to somewhere
         # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
-        self._noop_scope = Scope(self._noop_span)
+        self._noop_scope = Scope(self, self._noop_span)
 
-    def activate(self, span, finish_span_on_close=True):
+    def activate(self, span, finish_on_close=True):
         """
         Make a `Span` instance active.
 
         :param span: the `Span` that should become active
-        :param finish_span_on_close: whether span should automatically be
+        :param finish_on_close: whether span should automatically be
         finished when `Scope#close()` is called
         :return: a `Scope` instance to control the end of the active period for
         the `Span`. It is a programming error to neglect to call

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from opentracing.scope import Scope
+from opentracing.span import Span, SpanContext
+
+
+class ScopeManager(object):
+    """
+    The `ScopeManager` interface abstracts both the activation of `Span`
+    instances (via `ScopeManager#activate(Span)`) and access to an active
+    `Span` / `Scope` (via `ScopeManager#active()`).
+    """
+    def __init__(self):
+        # TODO: check that if it's required
+        self._noop_span = Span(tracer=None, context=SpanContext())
+        self._noop_scope = Scope(self._noop_span)
+
+    def activate(self, span, finish_span_on_close=True):
+        """
+        Make a `Span` instance active.
+
+        :param span: the `Span` that should become active
+        :param finish_span_on_close: whether span should automatically be
+        finished when `Scope#close()` is called
+        :return: a `Scope` instance to control the end of the active period for
+        the `Span`. It is a programming error to neglect to call
+        `Scope#close()` on the returned instance. By default, `Span` will
+        automatically be finished when `Scope#close()` is called.
+        """
+        return self._noop_scope
+
+    def active(self):
+        """
+        Return the currently active `Scope` which can be used to access the
+        currently active `Scope#span()`.
+
+        If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
+        parent of any newly-created `Span` at `Tracer#start_active()`
+        time.
+
+        :return: the `Scope` that is active, or `None` if not available.
+        """
+        return self._noop_scope

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -47,7 +47,7 @@ class Tracer(object):
 
     @property
     def scope_manager(self):
-        """Accessor for `ScopeManager`."""
+        """ScopeManager accessor"""
         return self._scope_manager
 
     def start_active(self,
@@ -58,10 +58,8 @@ class Tracer(object):
                      start_time=None,
                      ignore_active_scope=False,
                      finish_on_close=True):
-        """
-        Returns a newly started and activated `Scope`.
-
-        The returned `Scope` supports with-statement contexts. For example:
+        """Returns a newly started and activated `Scope`.
+        Returned `Scope` supports with-statement contexts. For example:
 
             with tracer.start_active('...') as scope:
                 scope.span().set_tag('http.method', 'GET')
@@ -91,7 +89,7 @@ class Tracer(object):
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time().
         :param ignore_active_scope: an explicit flag that ignores the current
-            active `Span` and creates a root `Span`.
+            active `Scope` and creates a root `Span`.
         :param finish_on_close: whether span should automatically be finished
             when `Scope#close()` is called.
 
@@ -142,7 +140,7 @@ class Tracer(object):
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
         :param ignore_active_scope: an explicit flag that ignores the current
-            active `Span` and creates a root `Span`.
+            active `Scope` and creates a root `Span`.
 
         :return: Returns an already-started Span instance.
         """

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -43,7 +43,7 @@ class Tracer(object):
         self._scope_manager = ScopeManager()
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
-        self._noop_scope = Scope(self._noop_span)
+        self._noop_scope = Scope(self._scope_manager, self._noop_span)
 
     @property
     def scope_manager(self):
@@ -56,7 +56,7 @@ class Tracer(object):
                      references=None,
                      tags=None,
                      start_time=None,
-                     ignore_active_span=False,
+                     ignore_active_scope=False,
                      finish_on_close=True):
         """
         Returns a newly started and activated `Scope`.
@@ -90,7 +90,7 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time().
-        :param ignore_active_span: an explicit flag that ignores the current
+        :param ignore_active_scope: an explicit flag that ignores the current
             active `Span` and creates a root `Span`.
         :param finish_on_close: whether span should automatically be finished
             when `Scope#close()` is called.
@@ -105,7 +105,7 @@ class Tracer(object):
                      references=None,
                      tags=None,
                      start_time=None,
-                     ignore_active_span=False):
+                     ignore_active_scope=False):
         """Starts and returns a new Span representing a unit of work.
 
 
@@ -141,7 +141,7 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
-        :param ignore_active_span: an explicit flag that ignores the current
+        :param ignore_active_scope: an explicit flag that ignores the current
             active `Span` and creates a root `Span`.
 
         :return: Returns an already-started Span instance.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,3 +33,6 @@ class APICheckNoopTracer(unittest.TestCase, APICompatibilityCheckMixin):
 
     def check_baggage_values(self):
         return False
+
+    def check_scope_manager(self):
+        return False

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -45,3 +45,9 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         # second check that assert on empty baggage will fail too
         with self.assertRaises(AssertionError):
             api_check.test_context_baggage()
+
+    def test_scope_manager_check_works(self):
+        api_check = APICompatibilityCheckMixin()
+        setattr(api_check, 'tracer', lambda: Tracer())
+
+        # TODO: list here all scope_manager checks

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -33,6 +33,10 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         api_check = APICompatibilityCheckMixin()
         assert api_check.check_baggage_values() is True
 
+    def test_default_scope_manager_check_mode(self):
+        api_check = APICompatibilityCheckMixin()
+        assert api_check.check_scope_manager() is True
+
     def test_baggage_check_works(self):
         api_check = APICompatibilityCheckMixin()
         setattr(api_check, 'tracer', lambda: Tracer())
@@ -50,4 +54,41 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         api_check = APICompatibilityCheckMixin()
         setattr(api_check, 'tracer', lambda: Tracer())
 
-        # TODO: list here all scope_manager checks
+        # these tests are expected to succeed
+        api_check.test_start_active_ignore_active_scope()
+        api_check.test_start_manual_propagation_ignore_active_scope()
+
+        # no-op tracer doesn't have a ScopeManager implementation
+        # so these tests are expected to work, but asserts to fail
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active_parent()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active_finish_on_close()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_manual_propagation()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_scope()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_nesting()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_nesting_finish_on_close()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_wrong_close_order()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_manual_scope()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_scope_manager_active()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_scope_manager_activate()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import mock
+
+from opentracing.tracer import Tracer
+from opentracing.scope import Scope
+from opentracing.span import Span, SpanContext
+
+
+def test_scope_wrapper():
+    # ensure `Scope` wraps the `Span` argument
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    assert scope._span == span
+    assert scope.span() == span
+
+
+def test_scope_context_manager():
+    # ensure `Scope` can be used in a Context Manager that
+    # calls the `close()` method
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    with mock.patch.object(scope, 'close') as close:
+        with scope:
+            pass
+        assert close.call_count == 1
+
+
+def test_scope_close():
+    # ensure `Scope` can be closed
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import mock
 
+from opentracing.scope_manager import ScopeManager
 from opentracing.tracer import Tracer
 from opentracing.scope import Scope
 from opentracing.span import Span, SpanContext
@@ -30,7 +31,7 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span, finish_span_on_close=False)
+    scope = Scope(ScopeManager, span, finish_on_close=False)
     assert scope._span == span
     assert scope.span() == span
 
@@ -39,7 +40,7 @@ def test_scope_context_manager():
     # ensure `Scope` can be used in a Context Manager that
     # calls the `close()` method
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(ScopeManager(), span)
     with mock.patch.object(scope, 'close') as close:
         with scope:
             pass
@@ -49,5 +50,5 @@ def test_scope_context_manager():
 def test_scope_close():
     # ensure `Scope` can be closed
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(ScopeManager(), span)
     scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -32,7 +32,6 @@ def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
     scope = Scope(ScopeManager, span, finish_on_close=False)
-    assert scope._span == span
     assert scope.span() == span
 
 
@@ -45,10 +44,3 @@ def test_scope_context_manager():
         with scope:
             pass
         assert close.call_count == 1
-
-
-def test_scope_close():
-    # ensure `Scope` can be closed
-    span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager(), span)
-    scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -30,7 +30,7 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(span, finish_span_on_close=False)
     assert scope._span == span
     assert scope.span() == span
 

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from opentracing.scope_manager import ScopeManager
+from opentracing.tracer import Tracer
+from opentracing.span import Span, SpanContext
+
+
+def test_scope_manager():
+    # ensure the activation returns the noop `Scope`
+    # that is always active
+    scope_manager = ScopeManager()
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = scope_manager.activate(span)
+    assert scope == scope_manager._noop_scope
+    assert scope == scope_manager.active()

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -26,8 +26,7 @@ from opentracing.span import Span, SpanContext
 
 
 def test_scope_manager():
-    # ensure the activation returns the noop `Scope`
-    # that is always active
+    # ensure the activation returns the noop `Scope` that is always active
     scope_manager = ScopeManager()
     span = Span(tracer=Tracer(), context=SpanContext())
     scope = scope_manager.activate(span)


### PR DESCRIPTION
### Overview

This PR aims to solve in-process context propagation for Python. It has two aims:

* adding a simple, high level API that allows very simple tracing that will handle 90% of use cases (`start_active()` and `start_manual()`)
* a pluggable interface (`ScopeManager`) that allows tracing async operations with all the common frameworks - threads, asyncio, tornado, etc

Implementation details are available in another PR (https://github.com/opentracing/basictracer-python/pull/24).

### Details

With this PR, `Scope` is implemented as a wrapper of `Span` class. No changes have been made to the current `Span` and `SpanContext`, making the propagation something built on top of current data models.

A `Scope` formalizes the activation and deactivation of a `Span`, that is handled using a `ScopeManager` available in the `Tracer` itself. It can be used automatically using tracing methods, or manually if you need to retrieve the current active `Span`. Simple examples are:

```python
def main():
    # `scope` will be automatically closed and the `Span` finished
    with tracer.start_active('request') as scope:
        scope.span().set_tag('http.url', url)
        do_something()

def do_something():
    scope = tracer.scope_manager.active()
    scope.span().set_tag('http.status_code', '200')
```

### Opened questions

* While I agree that obfuscating a function call with a property is not a shared opinion, I'd rather prefer having verbs in our methods (so `get_something`/`set_something` instead of just `something`). In Python such approach is not really idiomatic, though properties are. Because of that I suggest to have some internal attributes "protected" via a property like:
```python
# scope.py
scope = Scope(...)
scope.span  # instead of scope.span()
```
* The previous `Continuation` (and so the counter) is not part of this API, though it could be a `contrib` module in case we "really" need it in the future.
* No thread-local implementation since this is only the API. Details will be discussed in the reference implementation.

### References
* Supersede https://github.com/opentracing/opentracing-python/pull/52
* Based on Java API https://github.com/opentracing/opentracing-java/pull/188