### PR TITLE
Implement ScopeManager for in-process propagation (updated)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,18 +34,18 @@ The work of instrumentation libraries generally consists of three steps:
    Span object in the process. If the request does not contain an active trace,
    the service starts a new trace and a new *root* Span.
 2. The service needs to store the current Span in some request-local storage,
-   where it can be retrieved from when a child Span must be created, e.g. in case
-   of the service making an RPC to another service.
+   (called ``Span`` *activation*) where it can be retrieved from when a child Span must
+   be created, e.g. in case of the service making an RPC to another service.
 3. When making outbound calls to another service, the current Span must be
    retrieved from request-local storage, a child span must be created (e.g., by
    using the ``start_child_span()`` helper), and that child span must be embedded
    into the outbound request (e.g., using HTTP headers) via OpenTracing's
    inject/extract API.
 
-Below are the code examples for steps 1 and 3. Implementation of request-local
-storage needed for step 2 is specific to the service and/or frameworks /
-instrumentation libraries it is using (TODO: reference to other OSS projects
-with examples of instrumentation).
+Below are the code examples for the previously mentioned steps. Implementation
+of request-local storage needed for step 2 is specific to the service and/or frameworks /
+instrumentation libraries it is using, exposed as a ``ScopeManager`` child contained
+as ``Tracer.scope_manager``. See details below.
 
 Inbound request
 ^^^^^^^^^^^^^^^
@@ -56,12 +56,12 @@ Somewhere in your server's request handler code:
 
    def handle_request(request):
        span = before_request(request, opentracing.tracer)
-       # use span as Context Manager to ensure span.finish() will be called
-       with span:
-           # store span in some request-local storage
-           with RequestContext(span):
-               # actual business logic
-               handle_request_for_real(request)
+       # store span in some request-local storage using Tracer.scope_manager,
+       # using the returned `Scope` as Context Manager to ensure
+       # `Span` will be cleared and (in this case) `Span.finish()` be called.
+       with tracer.scope_manager.activate(span, True) as scope:
+           # actual business logic
+           handle_request_for_real(request)
 
 
    def before_request(request, tracer):
@@ -140,6 +140,61 @@ Somewhere in your service that's about to make an outgoing call:
            request.add_header(key, value)
 
        return outbound_span
+
+Scope and within-process propagation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For getting/setting the current active ``Span`` in the used request-local storage,
+OpenTracing requires that every ``Tracer`` contains a ``ScopeManager`` that grants
+access to the active ``Span`` through a ``Scope``. Any ``Span`` may be transferred to
+another task or thread, but not ``Scope``.
+
+.. code-block:: python
+
+       # Access to the active span is straightforward.
+       scope = tracer.scope_manager.active()
+       if scope is not None:
+           scope.span.set_tag('...', '...')
+
+The common case starts a ``Scope`` that's automatically registered for intra-process
+propagation via ``ScopeManager``.
+
+Note that ``start_active_span('...', True)`` finishes the span on ``Scope.close()``
+(``start_active_span('...', False)`` does not finish it, in contrast).
+
+.. code-block:: python
+
+       # Manual activation of the Span.
+       span = tracer.start_span(operation_name='someWork')
+       with tracer.scope_manager.activate(span, True) as scope:
+           # Do things.
+
+       # Automatic activation of the Span.
+       # finish_on_close is a required parameter.
+       with tracer.start_active_span('someWork', finish_on_close=True) as scope:
+           # Do things.
+
+       # Handling done through a try construct:
+       span = tracer.start_span(operation_name='someWork')
+       scope = tracer.scope_manager.activate(span, True)
+       try:
+           # Do things.
+       except Exception as e:
+           scope.set_tag('error', '...')
+       finally:
+           scope.finish()
+
+**If there is a Scope, it will act as the parent to any newly started Span** unless
+the programmer passes ``ignore_active_span=True`` at ``start_span()``/``start_active_span()``
+time or specified parent context explicitly:
+
+.. code-block:: python
+
+       scope = tracer.start_active_span('someWork', ignore_active_span=True)
+
+Each service/framework ought to provide a specific ``ScopeManager`` implementation
+that relies on their own request-local storage (thread-local storage, or coroutine-based storage
+for asynchronous frameworks, for example).
 
 Development
 -----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,12 @@ Classes
 .. autoclass:: opentracing.SpanContext
    :members:
 
+.. autoclass:: opentracing.Scope
+   :members:
+
+.. autoclass:: opentracing.ScopeManager
+   :members:
+
 .. autoclass:: opentracing.Tracer
    :members:
 

--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -22,6 +22,8 @@
 from __future__ import absolute_import
 from .span import Span  # noqa
 from .span import SpanContext  # noqa
+from .scope import Scope  # noqa
+from .scope_manager import ScopeManager  # noqa
 from .tracer import child_of  # noqa
 from .tracer import follows_from  # noqa
 from .tracer import Reference  # noqa

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -95,18 +95,18 @@ class APICompatibilityCheckMixin(object):
         with mock.patch.object(scope.span, 'finish') as finish:
             scope.close()
 
-        if self.check_scope_manager():
-            assert finish.call_count == 1
+        assert finish.call_count == 0
 
     def test_start_active_span_not_finish_on_close(self):
         # a `Span` is not finished when the flag is set
         tracer = self.tracer()
         scope = tracer.start_active_span(operation_name='Fry',
-                                         finish_on_close=False)
+                                         finish_on_close=True)
         with mock.patch.object(scope.span, 'finish') as finish:
             scope.close()
 
-        assert finish.call_count == 0
+        if self.check_scope_manager():
+            assert finish.call_count == 1
 
     def test_scope_as_context_manager(self):
         tracer = self.tracer()

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -47,21 +47,21 @@ class APICompatibilityCheckMixin(object):
 
     def check_scope_manager(self):
         """If true, the test suite will validate the `ScopeManager` propagation
-        and storage to ensure the correct parenting and active `Scope` are
-        properly defined by the implementation. If false, it will only use
-        the API without any assert. The latter mode is only useful for no-op
-        tracer.
+        to ensure correct parenting. If false, it will only use the API without
+        asserting. The latter mode is only useful for no-op tracer.
         """
         return True
 
     def is_parent(self, parent, span):
         """Utility method that must be defined by Tracer implementers to define
         how the test suite can check when a `Span` is a parent of another one.
+        It depends by the underlying implementation that is not part of the
+        OpenTracing API.
         """
         return False
 
     def test_start_span(self):
-        # test for deprecated API
+        # test deprecated API for minor compatibility
         tracer = self.tracer()
         span = tracer.start_span(operation_name='Fry')
         span.finish()
@@ -320,7 +320,7 @@ class APICompatibilityCheckMixin(object):
         # when a Scope is closed, the previous one must be activated
         tracer = self.tracer()
         with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Fry'):
+            with tracer.start_active(operation_name='Farnsworth'):
                 pass
 
             if self.check_scope_manager():
@@ -335,7 +335,7 @@ class APICompatibilityCheckMixin(object):
         parent = tracer.start_active(operation_name='Fry',
                                      finish_on_close=False)
         with mock.patch.object(parent.span(), 'finish') as finish:
-            with tracer.start_active(operation_name='Fry'):
+            with tracer.start_active(operation_name='Farnsworth'):
                 pass
             parent.close()
 
@@ -348,7 +348,7 @@ class APICompatibilityCheckMixin(object):
         # only the active `Scope` can be closed
         tracer = self.tracer()
         parent = tracer.start_active(operation_name='Fry')
-        child = tracer.start_active(operation_name='Fry')
+        child = tracer.start_active(operation_name='Farnsworth')
         parent.close()
 
         if self.check_scope_manager():

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -73,7 +73,8 @@ class APICompatibilityCheckMixin(object):
         # ensure the `ScopeManager` provides the right parenting
         tracer = self.tracer()
         with tracer.start_active_span(operation_name='Fry') as parent:
-            with tracer.start_active_span(operation_name='Farnsworth') as child:
+            with tracer.start_active_span(
+                    operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
                     assert self.is_parent(parent.span, child.span)
 
@@ -83,7 +84,7 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
         with tracer.start_active_span(operation_name='Fry') as parent:
             with tracer.start_active_span(operation_name='Farnsworth',
-                                     ignore_active_span=True) as child:
+                                          ignore_active_span=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span, child.span)
 
@@ -101,7 +102,7 @@ class APICompatibilityCheckMixin(object):
         # a `Span` is not finished when the flag is set
         tracer = self.tracer()
         scope = tracer.start_active_span(operation_name='Fry',
-                                    finish_on_close=False)
+                                         finish_on_close=False)
         with mock.patch.object(scope.span, 'finish') as finish:
             scope.close()
 
@@ -118,7 +119,7 @@ class APICompatibilityCheckMixin(object):
         span = tracer.start_span(operation_name='Fry')
         span.finish()
         with tracer.start_span(operation_name='Fry',
-                                 tags={'birthday': 'August 14 1974'}) as span:
+                               tags={'birthday': 'August 14 1974'}) as span:
             span.log_event('birthplace',
                            payload={'hospital': 'Brooklyn Pre-Med Hospital',
                                     'city': 'Old New York'})
@@ -137,7 +138,7 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
         with tracer.start_active_span(operation_name='Fry') as parent:
             with tracer.start_span(operation_name='Farnsworth',
-                                     ignore_active_span=True) as child:
+                                   ignore_active_span=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span, child)
 
@@ -322,7 +323,7 @@ class APICompatibilityCheckMixin(object):
         # finish_on_close must be correctly handled
         tracer = self.tracer()
         parent = tracer.start_active_span(operation_name='Fry',
-                                     finish_on_close=False)
+                                          finish_on_close=False)
         with mock.patch.object(parent.span, 'finish') as finish:
             with tracer.start_active_span(operation_name='Farnsworth'):
                 pass

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -60,58 +60,47 @@ class APICompatibilityCheckMixin(object):
         """
         return False
 
-    def test_start_span(self):
-        # test deprecated API for minor compatibility
-        tracer = self.tracer()
-        span = tracer.start_span(operation_name='Fry')
-        span.finish()
-        with tracer.start_span(operation_name='Fry',
-                               tags={'birthday': 'August 14 1974'}) as span:
-            span.log_event('birthplace',
-                           payload={'hospital': 'Brooklyn Pre-Med Hospital',
-                                    'city': 'Old New York'})
-
-    def test_start_active(self):
+    def test_start_active_span(self):
         # the first usage returns a `Scope` that wraps a root `Span`
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_span(operation_name='Fry')
 
         assert scope.span() is not None
         if self.check_scope_manager():
             assert self.is_parent(None, scope.span())
 
-    def test_start_active_parent(self):
+    def test_start_active_span_parent(self):
         # ensure the `ScopeManager` provides the right parenting
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth') as child:
+        with tracer.start_active_span(operation_name='Fry') as parent:
+            with tracer.start_active_span(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
                     assert self.is_parent(parent.span(), child.span())
 
-    def test_start_active_ignore_active_scope(self):
+    def test_start_active_span_ignore_active_span(self):
         # ensure the `ScopeManager` ignores the active `Scope`
         # if the flag is set
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth',
-                                     ignore_active_scope=True) as child:
+        with tracer.start_active_span(operation_name='Fry') as parent:
+            with tracer.start_active_span(operation_name='Farnsworth',
+                                     ignore_active_span=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span(), child.span())
 
-    def test_start_active_finish_on_close(self):
+    def test_start_active_span_finish_on_close(self):
         # ensure a `Span` is finished when the `Scope` close
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_span(operation_name='Fry')
         with mock.patch.object(scope.span(), 'finish') as finish:
             scope.close()
 
         if self.check_scope_manager():
             assert finish.call_count == 1
 
-    def test_start_active_not_finish_on_close(self):
+    def test_start_active_span_not_finish_on_close(self):
         # a `Span` is not finished when the flag is set
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry',
+        scope = tracer.start_active_span(operation_name='Fry',
                                     finish_on_close=False)
         with mock.patch.object(scope.span(), 'finish') as finish:
             scope.close()
@@ -121,46 +110,46 @@ class APICompatibilityCheckMixin(object):
     def test_scope_as_context_manager(self):
         tracer = self.tracer()
 
-        with tracer.start_active(operation_name='antiquing') as scope:
+        with tracer.start_active_span(operation_name='antiquing') as scope:
             assert scope.span() is not None
 
-    def test_start_manual(self):
+    def test_start_span(self):
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
         span.finish()
-        with tracer.start_manual(operation_name='Fry',
+        with tracer.start_span(operation_name='Fry',
                                  tags={'birthday': 'August 14 1974'}) as span:
             span.log_event('birthplace',
                            payload={'hospital': 'Brooklyn Pre-Med Hospital',
                                     'city': 'Old New York'})
 
-    def test_start_manual_propagation(self):
-        # `start_manual` must inherit the current active `Scope` span
+    def test_start_span_propagation(self):
+        # `start_span` must inherit the current active `Scope` span
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_manual(operation_name='Farnsworth') as child:
+        with tracer.start_active_span(operation_name='Fry') as parent:
+            with tracer.start_span(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
                     assert self.is_parent(parent.span(), child)
 
-    def test_start_manual_propagation_ignore_active_scope(self):
-        # `start_manual` doesn't inherit the current active `Scope` span
+    def test_start_span_propagation_ignore_active_span(self):
+        # `start_span` doesn't inherit the current active `Scope` span
         # if the flag is set
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_manual(operation_name='Farnsworth',
-                                     ignore_active_scope=True) as child:
+        with tracer.start_active_span(operation_name='Fry') as parent:
+            with tracer.start_span(operation_name='Farnsworth',
+                                     ignore_active_span=True) as child:
                 if self.check_scope_manager():
                     assert not self.is_parent(parent.span(), child)
 
-    def test_start_manual_with_parent(self):
+    def test_start_span_with_parent(self):
         tracer = self.tracer()
-        parent_span = tracer.start_manual(operation_name='parent')
+        parent_span = tracer.start_span(operation_name='parent')
         assert parent_span is not None
-        span = tracer.start_manual(
+        span = tracer.start_span(
             operation_name='Leela',
             child_of=parent_span)
         span.finish()
-        span = tracer.start_manual(
+        span = tracer.start_span(
             operation_name='Leela',
             references=[opentracing.follows_from(parent_span.context)],
             tags={'birthplace': 'sewers'})
@@ -169,7 +158,7 @@ class APICompatibilityCheckMixin(object):
 
     def test_start_child_span(self):
         tracer = self.tracer()
-        parent_span = tracer.start_manual(operation_name='parent')
+        parent_span = tracer.start_span(operation_name='parent')
         assert parent_span is not None
         child_span = opentracing.start_child_span(
             parent_span, operation_name='Leela')
@@ -177,7 +166,7 @@ class APICompatibilityCheckMixin(object):
         parent_span.finish()
 
     def test_set_operation_name(self):
-        span = self.tracer().start_manual().set_operation_name('Farnsworth')
+        span = self.tracer().start_span().set_operation_name('Farnsworth')
         span.finish()
 
     def test_span_as_context_manager(self):
@@ -187,14 +176,14 @@ class APICompatibilityCheckMixin(object):
         def mock_finish(*_):
             finish['called'] = True
 
-        with tracer.start_manual(operation_name='antiquing') as span:
+        with tracer.start_span(operation_name='antiquing') as span:
             setattr(span, 'finish', mock_finish)
         assert finish['called'] is True
 
         # now try with exception
         finish['called'] = False
         try:
-            with tracer.start_manual(operation_name='antiquing') as span:
+            with tracer.start_span(operation_name='antiquing') as span:
                 setattr(span, 'finish', mock_finish)
                 raise ValueError()
         except ValueError:
@@ -203,14 +192,14 @@ class APICompatibilityCheckMixin(object):
             raise AssertionError('Expected ValueError')  # pragma: no cover
 
     def test_span_tag_value_types(self):
-        with self.tracer().start_manual(operation_name='ManyTypes') as span:
+        with self.tracer().start_span(operation_name='ManyTypes') as span:
             span. \
                 set_tag('an_int', 9). \
                 set_tag('a_bool', True). \
                 set_tag('a_string', 'aoeuidhtns')
 
     def test_span_tags_with_chaining(self):
-        span = self.tracer().start_manual(operation_name='Farnsworth')
+        span = self.tracer().start_span(operation_name='Farnsworth')
         span. \
             set_tag('birthday', '9 April, 2841'). \
             set_tag('loves', 'different lengths of wires')
@@ -220,7 +209,7 @@ class APICompatibilityCheckMixin(object):
         span.finish()
 
     def test_span_logs(self):
-        span = self.tracer().start_manual(operation_name='Fry')
+        span = self.tracer().start_span(operation_name='Fry')
 
         # Newer API
         span.log_kv(
@@ -245,7 +234,7 @@ class APICompatibilityCheckMixin(object):
                 payload={'year': 2999})
 
     def test_span_baggage(self):
-        with self.tracer().start_manual(operation_name='Fry') as span:
+        with self.tracer().start_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span_ref = span.set_baggage_item('Kiff-loves', 'Amy')
             assert span_ref is span
@@ -255,7 +244,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_context_baggage(self):
-        with self.tracer().start_manual(operation_name='Fry') as span:
+        with self.tracer().start_span(operation_name='Fry') as span:
             assert span.context.baggage == {}
             span.set_baggage_item('Kiff-loves', 'Amy')
             if self.check_baggage_values():
@@ -263,7 +252,7 @@ class APICompatibilityCheckMixin(object):
             pass
 
     def test_text_propagation(self):
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             text_carrier = {}
             self.tracer().inject(
                 span_context=span.context,
@@ -275,7 +264,7 @@ class APICompatibilityCheckMixin(object):
             assert extracted_ctx.baggage == {}
 
     def test_binary_propagation(self):
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             bin_carrier = bytearray()
             self.tracer().inject(
                 span_context=span.context,
@@ -292,7 +281,7 @@ class APICompatibilityCheckMixin(object):
             (Format.HTTP_HEADERS, {}),
             (Format.BINARY, bytearray()),
         ]
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             for fmt, carrier in formats:
                 # expecting no exceptions
                 span.tracer.inject(span.context, fmt, carrier)
@@ -300,27 +289,27 @@ class APICompatibilityCheckMixin(object):
 
     def test_unknown_format(self):
         custom_format = 'kiss my shiny metal ...'
-        with self.tracer().start_manual(operation_name='Bender') as span:
+        with self.tracer().start_span(operation_name='Bender') as span:
             with pytest.raises(opentracing.UnsupportedFormatException):
                 span.tracer.inject(span.context, custom_format, {})
             with pytest.raises(opentracing.UnsupportedFormatException):
                 span.tracer.extract(custom_format, {})
 
-    def test_tracer_start_active_scope(self):
+    def test_tracer_start_active_span_scope(self):
         # the Tracer ScopeManager should store the active Scope
         tracer = self.tracer()
-        scope = tracer.start_active(operation_name='Fry')
+        scope = tracer.start_active_span(operation_name='Fry')
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() == scope
 
         scope.close()
 
-    def test_tracer_start_active_nesting(self):
+    def test_tracer_start_active_span_nesting(self):
         # when a Scope is closed, the previous one must be activated
         tracer = self.tracer()
-        with tracer.start_active(operation_name='Fry') as parent:
-            with tracer.start_active(operation_name='Farnsworth'):
+        with tracer.start_active_span(operation_name='Fry') as parent:
+            with tracer.start_active_span(operation_name='Farnsworth'):
                 pass
 
             if self.check_scope_manager():
@@ -329,13 +318,13 @@ class APICompatibilityCheckMixin(object):
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
 
-    def test_tracer_start_active_nesting_finish_on_close(self):
+    def test_tracer_start_active_span_nesting_finish_on_close(self):
         # finish_on_close must be correctly handled
         tracer = self.tracer()
-        parent = tracer.start_active(operation_name='Fry',
+        parent = tracer.start_active_span(operation_name='Fry',
                                      finish_on_close=False)
         with mock.patch.object(parent.span(), 'finish') as finish:
-            with tracer.start_active(operation_name='Farnsworth'):
+            with tracer.start_active_span(operation_name='Farnsworth'):
                 pass
             parent.close()
 
@@ -344,20 +333,20 @@ class APICompatibilityCheckMixin(object):
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
 
-    def test_tracer_start_active_wrong_close_order(self):
+    def test_tracer_start_active_span_wrong_close_order(self):
         # only the active `Scope` can be closed
         tracer = self.tracer()
-        parent = tracer.start_active(operation_name='Fry')
-        child = tracer.start_active(operation_name='Farnsworth')
+        parent = tracer.start_active_span(operation_name='Fry')
+        child = tracer.start_active_span(operation_name='Farnsworth')
         parent.close()
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() == child
 
-    def test_tracer_start_manual_scope(self):
+    def test_tracer_start_span_scope(self):
         # the Tracer ScopeManager should not store the new Span
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
 
         if self.check_scope_manager():
             assert tracer.scope_manager.active() is None
@@ -374,7 +363,7 @@ class APICompatibilityCheckMixin(object):
     def test_tracer_scope_manager_activate(self):
         # a `ScopeManager` should activate any `Span`
         tracer = self.tracer()
-        span = tracer.start_manual(operation_name='Fry')
+        span = tracer.start_span(operation_name='Fry')
         tracer.scope_manager.activate(span)
 
         if self.check_scope_manager():

--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -65,9 +65,9 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
         scope = tracer.start_active_span(operation_name='Fry')
 
-        assert scope.span() is not None
+        assert scope.span is not None
         if self.check_scope_manager():
-            assert self.is_parent(None, scope.span())
+            assert self.is_parent(None, scope.span)
 
     def test_start_active_span_parent(self):
         # ensure the `ScopeManager` provides the right parenting
@@ -75,7 +75,7 @@ class APICompatibilityCheckMixin(object):
         with tracer.start_active_span(operation_name='Fry') as parent:
             with tracer.start_active_span(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
-                    assert self.is_parent(parent.span(), child.span())
+                    assert self.is_parent(parent.span, child.span)
 
     def test_start_active_span_ignore_active_span(self):
         # ensure the `ScopeManager` ignores the active `Scope`
@@ -85,13 +85,13 @@ class APICompatibilityCheckMixin(object):
             with tracer.start_active_span(operation_name='Farnsworth',
                                      ignore_active_span=True) as child:
                 if self.check_scope_manager():
-                    assert not self.is_parent(parent.span(), child.span())
+                    assert not self.is_parent(parent.span, child.span)
 
     def test_start_active_span_finish_on_close(self):
         # ensure a `Span` is finished when the `Scope` close
         tracer = self.tracer()
         scope = tracer.start_active_span(operation_name='Fry')
-        with mock.patch.object(scope.span(), 'finish') as finish:
+        with mock.patch.object(scope.span, 'finish') as finish:
             scope.close()
 
         if self.check_scope_manager():
@@ -102,7 +102,7 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
         scope = tracer.start_active_span(operation_name='Fry',
                                     finish_on_close=False)
-        with mock.patch.object(scope.span(), 'finish') as finish:
+        with mock.patch.object(scope.span, 'finish') as finish:
             scope.close()
 
         assert finish.call_count == 0
@@ -111,7 +111,7 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
 
         with tracer.start_active_span(operation_name='antiquing') as scope:
-            assert scope.span() is not None
+            assert scope.span is not None
 
     def test_start_span(self):
         tracer = self.tracer()
@@ -129,7 +129,7 @@ class APICompatibilityCheckMixin(object):
         with tracer.start_active_span(operation_name='Fry') as parent:
             with tracer.start_span(operation_name='Farnsworth') as child:
                 if self.check_scope_manager():
-                    assert self.is_parent(parent.span(), child)
+                    assert self.is_parent(parent.span, child)
 
     def test_start_span_propagation_ignore_active_span(self):
         # `start_span` doesn't inherit the current active `Scope` span
@@ -139,7 +139,7 @@ class APICompatibilityCheckMixin(object):
             with tracer.start_span(operation_name='Farnsworth',
                                      ignore_active_span=True) as child:
                 if self.check_scope_manager():
-                    assert not self.is_parent(parent.span(), child)
+                    assert not self.is_parent(parent.span, child)
 
     def test_start_span_with_parent(self):
         tracer = self.tracer()
@@ -301,7 +301,7 @@ class APICompatibilityCheckMixin(object):
         scope = tracer.start_active_span(operation_name='Fry')
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() == scope
+            assert tracer.scope_manager.active == scope
 
         scope.close()
 
@@ -313,17 +313,17 @@ class APICompatibilityCheckMixin(object):
                 pass
 
             if self.check_scope_manager():
-                assert tracer.scope_manager.active() == parent
+                assert tracer.scope_manager.active == parent
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() is None
+            assert tracer.scope_manager.active is None
 
     def test_tracer_start_active_span_nesting_finish_on_close(self):
         # finish_on_close must be correctly handled
         tracer = self.tracer()
         parent = tracer.start_active_span(operation_name='Fry',
                                      finish_on_close=False)
-        with mock.patch.object(parent.span(), 'finish') as finish:
+        with mock.patch.object(parent.span, 'finish') as finish:
             with tracer.start_active_span(operation_name='Farnsworth'):
                 pass
             parent.close()
@@ -331,7 +331,7 @@ class APICompatibilityCheckMixin(object):
         assert finish.call_count == 0
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() is None
+            assert tracer.scope_manager.active is None
 
     def test_tracer_start_active_span_wrong_close_order(self):
         # only the active `Scope` can be closed
@@ -341,7 +341,7 @@ class APICompatibilityCheckMixin(object):
         parent.close()
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() == child
+            assert tracer.scope_manager.active == child
 
     def test_tracer_start_span_scope(self):
         # the Tracer ScopeManager should not store the new Span
@@ -349,7 +349,7 @@ class APICompatibilityCheckMixin(object):
         span = tracer.start_span(operation_name='Fry')
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() is None
+            assert tracer.scope_manager.active is None
 
         span.finish()
 
@@ -358,13 +358,13 @@ class APICompatibilityCheckMixin(object):
         tracer = self.tracer()
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active() is None
+            assert tracer.scope_manager.active is None
 
     def test_tracer_scope_manager_activate(self):
         # a `ScopeManager` should activate any `Span`
         tracer = self.tracer()
         span = tracer.start_span(operation_name='Fry')
-        tracer.scope_manager.activate(span)
+        tracer.scope_manager.activate(span, False)
 
         if self.check_scope_manager():
-            assert tracer.scope_manager.active().span() == span
+            assert tracer.scope_manager.active.span == span

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -30,17 +30,14 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, manager, span, finish_on_close):
+    def __init__(self, manager, span):
         """Initialize a `Scope` for the given `Span` object
 
         :param manager: the `ScopeManager` that created this `Scope`
         :param span: the `Span` used for this `Scope`
-        :param finish_on_close: whether span should automatically be
-            finished when `Scope#close()` is called
         """
         self._manager = manager
         self._span = span
-        self._finish_on_close = finish_on_close
 
     @property
     def span(self):
@@ -51,12 +48,6 @@ class Scope(object):
     def manager(self):
         """Return the `ScopeManager` that created this `Scope`."""
         return self._manager
-
-    @property
-    def finish_on_close(self):
-        """Return whether the span should automatically be finished
-        when `Scope#close()` is called."""
-        return self._finish_on_close
 
     def close(self):
         """Mark the end of the active period for the current thread and `Scope`,

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -31,7 +31,7 @@ class Scope(object):
     and on the path.
     """
     def __init__(self, manager, span):
-        """Initialize a `Scope` for the given `Span` object
+        """Initializes a `Scope` for the given `Span` object.
 
         :param manager: the `ScopeManager` that created this `Scope`
         :param span: the `Span` used for this `Scope`
@@ -41,17 +41,17 @@ class Scope(object):
 
     @property
     def span(self):
-        """Return the `Span` that's been scoped by this `Scope`."""
+        """Returns the `Span` wrapped by this `Scope`."""
         return self._span
 
     @property
     def manager(self):
-        """Return the `ScopeManager` that created this `Scope`."""
+        """Returns the `ScopeManager` that created this `Scope`."""
         return self._manager
 
     def close(self):
-        """Mark the end of the active period for the current thread and `Scope`,
-        updating the `ScopeManager#active` in the process.
+        """Marks the end of the active period for this `Scope`,
+        updating `ScopeManager#active` in the process.
 
         NOTE: Calling `close()` more than once on a single `Scope` instance
         leads to undefined behavior.
@@ -59,11 +59,11 @@ class Scope(object):
         pass
 
     def __enter__(self):
-        """Allow `Scope` to be used inside a Python Context Manager."""
+        """Allows `Scope` to be used inside a Python Context Manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Call `close()` when the execution is outside the Python
+        """Calls `close()` when the execution is outside the Python
         Context Manager.
         """
         self.close()

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+
+class Scope(object):
+    """
+    A `Scope` formalizes the activation and deactivation of a `Span`, usually
+    from a CPU standpoint. Many times a `Span` will be extant (in that
+    `Span#finish()` has not been called) despite being in a non-runnable state
+    from a CPU/scheduler standpoint. For instance, a `Span` representing the
+    client side of an RPC will be unfinished but blocked on IO while the RPC is
+    still outstanding. A `Scope` defines when a given `Span` is scheduled
+    and on the path.
+    """
+    def __init__(self, span):
+        """
+        Initialize a `Scope` for the given `Span` object
+
+        :param span: the `Span` used for this `Scope`
+        """
+        # TODO: maybe it should always be the NoopSpan?
+        # something similar to:
+        # self._noop_span_context = SpanContext()
+        # self._noop_span = Span(tracer=self, context=self._noop_span_context)
+        self._span = span
+
+    def span(self):
+        """
+        Return the `Span` that's been scoped by this `Scope`.
+        """
+        return self._span
+
+    def close(self):
+        """
+        Mark the end of the active period for the current thread and `Scope`,
+        updating the `ScopeManager#active()` in the process.
+
+        NOTE: Calling `close()` more than once on a single `Scope` instance
+        leads to undefined behavior.
+        """
+        pass
+
+    def __enter__(self):
+        """
+        Allow `Scope` to be used inside a Python Context Manager.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Call `close()` when the execution is outside the Python
+        Context Manager.
+        """
+        self.close()

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -31,16 +31,14 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, span):
+    def __init__(self, span, finish_span_on_close=True):
         """
         Initialize a `Scope` for the given `Span` object
 
         :param span: the `Span` used for this `Scope`
+        :param finish_span_on_close: whether span should automatically be
+            finished when `Scope#close()` is called
         """
-        # TODO: maybe it should always be the NoopSpan?
-        # something similar to:
-        # self._noop_span_context = SpanContext()
-        # self._noop_span = Span(tracer=self, context=self._noop_span_context)
         self._span = span
 
     def span(self):

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -31,14 +31,15 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, span, finish_span_on_close=True):
+    def __init__(self, manager, span, finish_on_close=True):
         """
         Initialize a `Scope` for the given `Span` object
 
         :param span: the `Span` used for this `Scope`
-        :param finish_span_on_close: whether span should automatically be
+        :param finish_on_close: whether span should automatically be
             finished when `Scope#close()` is called
         """
+        self._manager = manager
         self._span = span
 
     def span(self):

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -22,9 +22,8 @@ from __future__ import absolute_import
 
 
 class Scope(object):
-    """
-    A `Scope` formalizes the activation and deactivation of a `Span`, usually
-    from a CPU standpoint. Many times a `Span` will be extant (in that
+    """A `Scope` formalizes the activation and deactivation of a `Span`,
+    usually from a CPU standpoint. Many times a `Span` will be extant (in that
     `Span#finish()` has not been called) despite being in a non-runnable state
     from a CPU/scheduler standpoint. For instance, a `Span` representing the
     client side of an RPC will be unfinished but blocked on IO while the RPC is
@@ -32,9 +31,9 @@ class Scope(object):
     and on the path.
     """
     def __init__(self, manager, span, finish_on_close=True):
-        """
-        Initialize a `Scope` for the given `Span` object
+        """Initialize a `Scope` for the given `Span` object
 
+        :param manager: the `ScopeManager` that created this `Scope`
         :param span: the `Span` used for this `Scope`
         :param finish_on_close: whether span should automatically be
             finished when `Scope#close()` is called
@@ -43,14 +42,11 @@ class Scope(object):
         self._span = span
 
     def span(self):
-        """
-        Return the `Span` that's been scoped by this `Scope`.
-        """
+        """Return the `Span` that's been scoped by this `Scope`."""
         return self._span
 
     def close(self):
-        """
-        Mark the end of the active period for the current thread and `Scope`,
+        """Mark the end of the active period for the current thread and `Scope`,
         updating the `ScopeManager#active()` in the process.
 
         NOTE: Calling `close()` more than once on a single `Scope` instance
@@ -59,14 +55,11 @@ class Scope(object):
         pass
 
     def __enter__(self):
-        """
-        Allow `Scope` to be used inside a Python Context Manager.
-        """
+        """Allow `Scope` to be used inside a Python Context Manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """
-        Call `close()` when the execution is outside the Python
+        """Call `close()` when the execution is outside the Python
         Context Manager.
         """
         self.close()

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -30,7 +30,7 @@ class Scope(object):
     still outstanding. A `Scope` defines when a given `Span` is scheduled
     and on the path.
     """
-    def __init__(self, manager, span, finish_on_close=True):
+    def __init__(self, manager, span, finish_on_close):
         """Initialize a `Scope` for the given `Span` object
 
         :param manager: the `ScopeManager` that created this `Scope`
@@ -40,14 +40,27 @@ class Scope(object):
         """
         self._manager = manager
         self._span = span
+        self._finish_on_close = finish_on_close
 
+    @property
     def span(self):
         """Return the `Span` that's been scoped by this `Scope`."""
         return self._span
 
+    @property
+    def manager(self):
+        """Return the `ScopeManager` that created this `Scope`."""
+        return self._manager
+
+    @property
+    def finish_on_close(self):
+        """Return whether the span should automatically be finished
+        when `Scope#close()` is called."""
+        return self._finish_on_close
+
     def close(self):
         """Mark the end of the active period for the current thread and `Scope`,
-        updating the `ScopeManager#active()` in the process.
+        updating the `ScopeManager#active` in the process.
 
         NOTE: Calling `close()` more than once on a single `Scope` instance
         leads to undefined behavior.

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -26,8 +26,8 @@ from .scope import Scope
 
 class ScopeManager(object):
     """The `ScopeManager` interface abstracts both the activation of `Span`
-    instances (via `ScopeManager#activate(Span)`) and access to an active
-    `Span` / `Scope` (via `ScopeManager#active`).
+    instances (via `ScopeManager#activate(span, finish_on_close)`) and
+    access to an active `Span` / `Scope` (via `ScopeManager#active`).
     """
     def __init__(self):
         # TODO: `tracer` should not be None, but we don't have a reference;
@@ -37,20 +37,21 @@ class ScopeManager(object):
         self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close):
-        """Make a `Span` instance active.
+        """Makes a `Span` instance active.
 
-        :param span: the `Span` that should become active
-        :param finish_on_close: whether span should automatically be
-        finished when `Scope#close()` is called
+        :param span: the `Span` that should become active.
+        :param finish_on_close: whether span should be automatically
+            finished when `Scope#close()` is called.
+
         :return: a `Scope` instance to control the end of the active period for
-        the `Span`. It is a programming error to neglect to call
-        `Scope#close()` on the returned instance.
+            the `Span`. It is a programming error to neglect to call
+            `Scope#close()` on the returned instance.
         """
         return self._noop_scope
 
     @property
     def active(self):
-        """Return the currently active `Scope` which can be used to access the
+        """Returns the currently active `Scope` which can be used to access the
         currently active `Scope#span`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -31,7 +31,9 @@ class ScopeManager(object):
     `Span` / `Scope` (via `ScopeManager#active()`).
     """
     def __init__(self):
-        # TODO: check that if it's required
+        # TODO: `tracer` should not be None, but we don't have a reference;
+        # should we move the NOOP SpanContext, Span, Scope to somewhere
+        # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
         self._noop_scope = Scope(self._noop_span)
 

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -34,7 +34,7 @@ class ScopeManager(object):
         # should we move the NOOP SpanContext, Span, Scope to somewhere
         # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
-        self._noop_scope = Scope(self, self._noop_span, False)
+        self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close):
         """Make a `Span` instance active.

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -20,8 +20,8 @@
 
 from __future__ import absolute_import
 
-from opentracing.scope import Scope
-from opentracing.span import Span, SpanContext
+from .span import Span, SpanContext
+from .scope import Scope
 
 
 class ScopeManager(object):

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -25,8 +25,7 @@ from .scope import Scope
 
 
 class ScopeManager(object):
-    """
-    The `ScopeManager` interface abstracts both the activation of `Span`
+    """The `ScopeManager` interface abstracts both the activation of `Span`
     instances (via `ScopeManager#activate(Span)`) and access to an active
     `Span` / `Scope` (via `ScopeManager#active()`).
     """
@@ -38,8 +37,7 @@ class ScopeManager(object):
         self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close=True):
-        """
-        Make a `Span` instance active.
+        """Make a `Span` instance active.
 
         :param span: the `Span` that should become active
         :param finish_on_close: whether span should automatically be
@@ -52,8 +50,7 @@ class ScopeManager(object):
         return self._noop_scope
 
     def active(self):
-        """
-        Return the currently active `Scope` which can be used to access the
+        """Return the currently active `Scope` which can be used to access the
         currently active `Scope#span()`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -27,16 +27,16 @@ from .scope import Scope
 class ScopeManager(object):
     """The `ScopeManager` interface abstracts both the activation of `Span`
     instances (via `ScopeManager#activate(Span)`) and access to an active
-    `Span` / `Scope` (via `ScopeManager#active()`).
+    `Span` / `Scope` (via `ScopeManager#active`).
     """
     def __init__(self):
         # TODO: `tracer` should not be None, but we don't have a reference;
         # should we move the NOOP SpanContext, Span, Scope to somewhere
         # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
-        self._noop_scope = Scope(self, self._noop_span)
+        self._noop_scope = Scope(self, self._noop_span, False)
 
-    def activate(self, span, finish_on_close=True):
+    def activate(self, span, finish_on_close):
         """Make a `Span` instance active.
 
         :param span: the `Span` that should become active
@@ -44,17 +44,17 @@ class ScopeManager(object):
         finished when `Scope#close()` is called
         :return: a `Scope` instance to control the end of the active period for
         the `Span`. It is a programming error to neglect to call
-        `Scope#close()` on the returned instance. By default, `Span` will
-        automatically be finished when `Scope#close()` is called.
+        `Scope#close()` on the returned instance.
         """
         return self._noop_scope
 
+    @property
     def active(self):
         """Return the currently active `Scope` which can be used to access the
-        currently active `Scope#span()`.
+        currently active `Scope#span`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
-        parent of any newly-created `Span` at `Tracer#start_active()`
+        parent of any newly-created `Span` at `Tracer#start_active_span()`
         time.
 
         :return: the `Scope` that is active, or `None` if not available.

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -35,14 +35,14 @@ class ScopeManager(object):
         # should we move the NOOP SpanContext, Span, Scope to somewhere
         # else so that they're globally reachable?
         self._noop_span = Span(tracer=None, context=SpanContext())
-        self._noop_scope = Scope(self._noop_span)
+        self._noop_scope = Scope(self, self._noop_span)
 
-    def activate(self, span, finish_span_on_close=True):
+    def activate(self, span, finish_on_close=True):
         """
         Make a `Span` instance active.
 
         :param span: the `Span` that should become active
-        :param finish_span_on_close: whether span should automatically be
+        :param finish_on_close: whether span should automatically be
         finished when `Scope#close()` is called
         :return: a `Scope` instance to control the end of the active period for
         the `Span`. It is a programming error to neglect to call

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from opentracing.scope import Scope
+from opentracing.span import Span, SpanContext
+
+
+class ScopeManager(object):
+    """
+    The `ScopeManager` interface abstracts both the activation of `Span`
+    instances (via `ScopeManager#activate(Span)`) and access to an active
+    `Span` / `Scope` (via `ScopeManager#active()`).
+    """
+    def __init__(self):
+        # TODO: check that if it's required
+        self._noop_span = Span(tracer=None, context=SpanContext())
+        self._noop_scope = Scope(self._noop_span)
+
+    def activate(self, span, finish_span_on_close=True):
+        """
+        Make a `Span` instance active.
+
+        :param span: the `Span` that should become active
+        :param finish_span_on_close: whether span should automatically be
+        finished when `Scope#close()` is called
+        :return: a `Scope` instance to control the end of the active period for
+        the `Span`. It is a programming error to neglect to call
+        `Scope#close()` on the returned instance. By default, `Span` will
+        automatically be finished when `Scope#close()` is called.
+        """
+        return self._noop_scope
+
+    def active(self):
+        """
+        Return the currently active `Scope` which can be used to access the
+        currently active `Scope#span()`.
+
+        If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
+        parent of any newly-created `Span` at `Tracer#start_active()`
+        time.
+
+        :return: the `Scope` that is active, or `None` if not available.
+        """
+        return self._noop_scope

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -39,8 +39,8 @@ class Tracer(object):
 
     _supported_formats = [Format.TEXT_MAP, Format.BINARY, Format.HTTP_HEADERS]
 
-    def __init__(self):
-        self._scope_manager = ScopeManager()
+    def __init__(self, scope_manager=ScopeManager()):
+        self._scope_manager = scope_manager
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
         self._noop_scope = Scope(self._scope_manager, self._noop_span, False)

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -51,13 +51,13 @@ class Tracer(object):
         return self._scope_manager
 
     def start_active_span(self,
-                     operation_name=None,
-                     child_of=None,
-                     references=None,
-                     tags=None,
-                     start_time=None,
-                     ignore_active_span=False,
-                     finish_on_close=False):
+                          operation_name=None,
+                          child_of=None,
+                          references=None,
+                          tags=None,
+                          start_time=None,
+                          ignore_active_span=False,
+                          finish_on_close=False):
         """Returns a newly started and activated `Scope`.
         Returned `Scope` supports with-statement contexts. For example:
 
@@ -69,7 +69,8 @@ class Tracer(object):
         It's also possible to finish the `Span` when the `Scope` context
         expires:
 
-            with tracer.start_active_span('...', finish_on_close=True) as scope:
+            with tracer.start_active_span('...',
+                                          finish_on_close=True) as scope:
                 scope.span.set_tag('http.method', 'GET')
                 do_some_work()
             # Span finishes automatically when the Scope is closed as

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -39,8 +39,9 @@ class Tracer(object):
 
     _supported_formats = [Format.TEXT_MAP, Format.BINARY, Format.HTTP_HEADERS]
 
-    def __init__(self, scope_manager=ScopeManager()):
-        self._scope_manager = scope_manager
+    def __init__(self, scope_manager=None):
+        self._scope_manager = ScopeManager() if scope_manager is None \
+                else scope_manager
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
         self._noop_scope = Scope(self._scope_manager, self._noop_span)

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -43,7 +43,7 @@ class Tracer(object):
         self._scope_manager = scope_manager
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
-        self._noop_scope = Scope(self._scope_manager, self._noop_span, False)
+        self._noop_scope = Scope(self._scope_manager, self._noop_span)
 
     @property
     def scope_manager(self):

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -60,12 +60,13 @@ class Tracer(object):
                           start_time=None,
                           ignore_active_span=False):
         """Returns a newly started and activated `Scope`.
-        Returned `Scope` supports with-statement contexts. For example:
 
-            with tracer.start_active_span('...') as scope:
+        The returned `Scope` supports with-statement contexts. For example:
+
+            with tracer.start_active_span('...', False) as scope:
                 scope.span.set_tag('http.method', 'GET')
                 do_some_work()
-            # Span is *not* finished automatically outside the `Scope` `with`.
+            # Span is not finished outside the `Scope` `with`.
 
         It's also possible to finish the `Span` when the `Scope` context
         expires:
@@ -73,11 +74,13 @@ class Tracer(object):
             with tracer.start_active_span('...', True) as scope:
                 scope.span.set_tag('http.method', 'GET')
                 do_some_work()
-            # Span finishes automatically when the Scope is closed as
+            # Span finishes when the Scope is closed as
             # `finish_on_close` is `True`
 
         :param operation_name: name of the operation represented by the new
             span from the perspective of the current service.
+        :param finish_on_close: whether span should automatically be finished
+            when `Scope#close()` is called.
         :param child_of: (optional) a Span or SpanContext instance representing
             the parent in a REFERENCE_CHILD_OF Reference. If specified, the
             `references` parameter must be omitted.
@@ -89,10 +92,8 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time().
-        :param ignore_active_span: an explicit flag that ignores the current
-            active `Scope` and creates a root `Span`.
-        :param finish_on_close: whether span should automatically be finished
-            when `Scope#close()` is called.
+        :param ignore_active_span: (optional) an explicit flag that ignores
+            the current active `Scope` and creates a root `Span`.
 
          :return: a `Scope`, already registered via the `ScopeManager`.
         """

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -47,7 +47,7 @@ class Tracer(object):
 
     @property
     def scope_manager(self):
-        """Accessor for `ScopeManager`."""
+        """ScopeManager accessor"""
         return self._scope_manager
 
     def start_active(self,
@@ -58,10 +58,8 @@ class Tracer(object):
                      start_time=None,
                      ignore_active_scope=False,
                      finish_on_close=True):
-        """
-        Returns a newly started and activated `Scope`.
-
-        The returned `Scope` supports with-statement contexts. For example:
+        """Returns a newly started and activated `Scope`.
+        Returned `Scope` supports with-statement contexts. For example:
 
             with tracer.start_active('...') as scope:
                 scope.span().set_tag('http.method', 'GET')
@@ -91,7 +89,7 @@ class Tracer(object):
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time().
         :param ignore_active_scope: an explicit flag that ignores the current
-            active `Span` and creates a root `Span`.
+            active `Scope` and creates a root `Span`.
         :param finish_on_close: whether span should automatically be finished
             when `Scope#close()` is called.
 
@@ -142,7 +140,7 @@ class Tracer(object):
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
         :param ignore_active_scope: an explicit flag that ignores the current
-            active `Span` and creates a root `Span`.
+            active `Scope` and creates a root `Span`.
 
         :return: Returns an already-started Span instance.
         """

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -51,13 +51,13 @@ class Tracer(object):
         return self._scope_manager
 
     def start_active_span(self,
-                          operation_name=None,
+                          operation_name,
+                          finish_on_close,
                           child_of=None,
                           references=None,
                           tags=None,
                           start_time=None,
-                          ignore_active_span=False,
-                          finish_on_close=False):
+                          ignore_active_span=False):
         """Returns a newly started and activated `Scope`.
         Returned `Scope` supports with-statement contexts. For example:
 
@@ -69,8 +69,7 @@ class Tracer(object):
         It's also possible to finish the `Span` when the `Scope` context
         expires:
 
-            with tracer.start_active_span('...',
-                                          finish_on_close=True) as scope:
+            with tracer.start_active_span('...', True) as scope:
                 scope.span.set_tag('http.method', 'GET')
                 do_some_work()
             # Span finishes automatically when the Scope is closed as

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -43,7 +43,7 @@ class Tracer(object):
         self._scope_manager = ScopeManager()
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
-        self._noop_scope = Scope(self._noop_span)
+        self._noop_scope = Scope(self._scope_manager, self._noop_span)
 
     @property
     def scope_manager(self):
@@ -56,7 +56,7 @@ class Tracer(object):
                      references=None,
                      tags=None,
                      start_time=None,
-                     ignore_active_span=False,
+                     ignore_active_scope=False,
                      finish_on_close=True):
         """
         Returns a newly started and activated `Scope`.
@@ -90,7 +90,7 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time().
-        :param ignore_active_span: an explicit flag that ignores the current
+        :param ignore_active_scope: an explicit flag that ignores the current
             active `Span` and creates a root `Span`.
         :param finish_on_close: whether span should automatically be finished
             when `Scope#close()` is called.
@@ -105,7 +105,7 @@ class Tracer(object):
                      references=None,
                      tags=None,
                      start_time=None,
-                     ignore_active_span=False):
+                     ignore_active_scope=False):
         """Starts and returns a new Span representing a unit of work.
 
 
@@ -141,7 +141,7 @@ class Tracer(object):
             to avoid extra data copying.
         :param start_time: an explicit Span start time as a unix timestamp per
             time.time()
-        :param ignore_active_span: an explicit flag that ignores the current
+        :param ignore_active_scope: an explicit flag that ignores the current
             active `Span` and creates a root `Span`.
 
         :return: Returns an already-started Span instance.

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -43,7 +43,7 @@ class Tracer(object):
         self._scope_manager = ScopeManager()
         self._noop_span_context = SpanContext()
         self._noop_span = Span(tracer=self, context=self._noop_span_context)
-        self._noop_scope = Scope(self._scope_manager, self._noop_span)
+        self._noop_scope = Scope(self._scope_manager, self._noop_span, False)
 
     @property
     def scope_manager(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,3 +33,6 @@ class APICheckNoopTracer(unittest.TestCase, APICompatibilityCheckMixin):
 
     def check_baggage_values(self):
         return False
+
+    def check_scope_manager(self):
+        return False

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -55,37 +55,37 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         setattr(api_check, 'tracer', lambda: Tracer())
 
         # these tests are expected to succeed
-        api_check.test_start_active_ignore_active_scope()
-        api_check.test_start_manual_propagation_ignore_active_scope()
+        api_check.test_start_active_span_ignore_active_span()
+        api_check.test_start_span_propagation_ignore_active_span()
 
         # no-op tracer doesn't have a ScopeManager implementation
         # so these tests are expected to work, but asserts to fail
         with self.assertRaises(AssertionError):
-            api_check.test_start_active()
+            api_check.test_start_active_span()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_active_parent()
+            api_check.test_start_active_span_parent()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_active_finish_on_close()
+            api_check.test_start_active_span_finish_on_close()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_manual_propagation()
+            api_check.test_start_span_propagation()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_scope()
+            api_check.test_tracer_start_active_span_scope()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_nesting()
+            api_check.test_tracer_start_active_span_nesting()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_nesting_finish_on_close()
+            api_check.test_tracer_start_active_span_nesting_finish_on_close()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_active_wrong_close_order()
+            api_check.test_tracer_start_active_span_wrong_close_order()
 
         with self.assertRaises(AssertionError):
-            api_check.test_tracer_start_manual_scope()
+            api_check.test_tracer_start_span_scope()
 
         with self.assertRaises(AssertionError):
             api_check.test_tracer_scope_manager_active()

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -67,9 +67,6 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
             api_check.test_start_active_span_parent()
 
         with self.assertRaises(AssertionError):
-            api_check.test_start_active_span_finish_on_close()
-
-        with self.assertRaises(AssertionError):
             api_check.test_start_span_propagation()
 
         with self.assertRaises(AssertionError):
@@ -92,3 +89,6 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             api_check.test_tracer_scope_manager_activate()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active_span_not_finish_on_close()

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -45,3 +45,9 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         # second check that assert on empty baggage will fail too
         with self.assertRaises(AssertionError):
             api_check.test_context_baggage()
+
+    def test_scope_manager_check_works(self):
+        api_check = APICompatibilityCheckMixin()
+        setattr(api_check, 'tracer', lambda: Tracer())
+
+        # TODO: list here all scope_manager checks

--- a/tests/test_api_check_mixin.py
+++ b/tests/test_api_check_mixin.py
@@ -33,6 +33,10 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         api_check = APICompatibilityCheckMixin()
         assert api_check.check_baggage_values() is True
 
+    def test_default_scope_manager_check_mode(self):
+        api_check = APICompatibilityCheckMixin()
+        assert api_check.check_scope_manager() is True
+
     def test_baggage_check_works(self):
         api_check = APICompatibilityCheckMixin()
         setattr(api_check, 'tracer', lambda: Tracer())
@@ -50,4 +54,41 @@ class VerifyAPICompatibilityCheck(unittest.TestCase):
         api_check = APICompatibilityCheckMixin()
         setattr(api_check, 'tracer', lambda: Tracer())
 
-        # TODO: list here all scope_manager checks
+        # these tests are expected to succeed
+        api_check.test_start_active_ignore_active_scope()
+        api_check.test_start_manual_propagation_ignore_active_scope()
+
+        # no-op tracer doesn't have a ScopeManager implementation
+        # so these tests are expected to work, but asserts to fail
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active_parent()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_active_finish_on_close()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_start_manual_propagation()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_scope()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_nesting()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_nesting_finish_on_close()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_active_wrong_close_order()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_start_manual_scope()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_scope_manager_active()
+
+        with self.assertRaises(AssertionError):
+            api_check.test_tracer_scope_manager_activate()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import mock
+
+from opentracing.tracer import Tracer
+from opentracing.scope import Scope
+from opentracing.span import Span, SpanContext
+
+
+def test_scope_wrapper():
+    # ensure `Scope` wraps the `Span` argument
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    assert scope._span == span
+    assert scope.span() == span
+
+
+def test_scope_context_manager():
+    # ensure `Scope` can be used in a Context Manager that
+    # calls the `close()` method
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    with mock.patch.object(scope, 'close') as close:
+        with scope:
+            pass
+        assert close.call_count == 1
+
+
+def test_scope_close():
+    # ensure `Scope` can be closed
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = Scope(span)
+    scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import mock
 
+from opentracing.scope_manager import ScopeManager
 from opentracing.tracer import Tracer
 from opentracing.scope import Scope
 from opentracing.span import Span, SpanContext
@@ -30,7 +31,7 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span, finish_span_on_close=False)
+    scope = Scope(ScopeManager, span, finish_on_close=False)
     assert scope._span == span
     assert scope.span() == span
 
@@ -39,7 +40,7 @@ def test_scope_context_manager():
     # ensure `Scope` can be used in a Context Manager that
     # calls the `close()` method
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(ScopeManager(), span)
     with mock.patch.object(scope, 'close') as close:
         with scope:
             pass
@@ -49,5 +50,5 @@ def test_scope_context_manager():
 def test_scope_close():
     # ensure `Scope` can be closed
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(ScopeManager(), span)
     scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -31,7 +31,7 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager, span, False)
+    scope = Scope(ScopeManager, span)
     assert scope.span == span
 
 
@@ -39,7 +39,7 @@ def test_scope_context_manager():
     # ensure `Scope` can be used in a Context Manager that
     # calls the `close()` method
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager(), span, True)
+    scope = Scope(ScopeManager(), span)
     with mock.patch.object(scope, 'close') as close:
         with scope:
             pass

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -31,15 +31,15 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager, span, finish_on_close=False)
-    assert scope.span() == span
+    scope = Scope(ScopeManager, span, False)
+    assert scope.span == span
 
 
 def test_scope_context_manager():
     # ensure `Scope` can be used in a Context Manager that
     # calls the `close()` method
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager(), span)
+    scope = Scope(ScopeManager(), span, True)
     with mock.patch.object(scope, 'close') as close:
         with scope:
             pass

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -32,7 +32,6 @@ def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
     scope = Scope(ScopeManager, span, finish_on_close=False)
-    assert scope._span == span
     assert scope.span() == span
 
 
@@ -45,10 +44,3 @@ def test_scope_context_manager():
         with scope:
             pass
         assert close.call_count == 1
-
-
-def test_scope_close():
-    # ensure `Scope` can be closed
-    span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(ScopeManager(), span)
-    scope.close()

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -30,7 +30,7 @@ from opentracing.span import Span, SpanContext
 def test_scope_wrapper():
     # ensure `Scope` wraps the `Span` argument
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = Scope(span)
+    scope = Scope(span, finish_span_on_close=False)
     assert scope._span == span
     assert scope.span() == span
 

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from opentracing.scope_manager import ScopeManager
+from opentracing.tracer import Tracer
+from opentracing.span import Span, SpanContext
+
+
+def test_scope_manager():
+    # ensure the activation returns the noop `Scope`
+    # that is always active
+    scope_manager = ScopeManager()
+    span = Span(tracer=Tracer(), context=SpanContext())
+    scope = scope_manager.activate(span)
+    assert scope == scope_manager._noop_scope
+    assert scope == scope_manager.active()

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -26,8 +26,7 @@ from opentracing.span import Span, SpanContext
 
 
 def test_scope_manager():
-    # ensure the activation returns the noop `Scope`
-    # that is always active
+    # ensure the activation returns the noop `Scope` that is always active
     scope_manager = ScopeManager()
     span = Span(tracer=Tracer(), context=SpanContext())
     scope = scope_manager.activate(span)

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -29,6 +29,6 @@ def test_scope_manager():
     # ensure the activation returns the noop `Scope` that is always active
     scope_manager = ScopeManager()
     span = Span(tracer=Tracer(), context=SpanContext())
-    scope = scope_manager.activate(span)
+    scope = scope_manager.activate(span, False)
     assert scope == scope_manager._noop_scope
-    assert scope == scope_manager.active()
+    assert scope == scope_manager.active


### PR DESCRIPTION
This is an updated PR for supporting `Span` propagation, sitting on top of @palazzem's effort (#63), and updated with the feedback received there, as well as updated with the latest Java API.

Summary of changes:

* `Tracer.start_manual` was removed.
* `Tracer.start_span` stays, without being deprecated, but **now** by default sets the active `Span` as the parent one, if any. This is a breaking change, and passing `ignore_active_span=True` will get the previous behavior.
* `Tracer.start_active` became `Tracer.start_active_span` (longer, but better, more complete name overall).
* `finish_on_close` became non-optional, being only left as optional in `start_active_span` as `False` (as _all_ its parameters are optional, even `operation_name`).
* Added `Scope.manager`, similar to `Span.tracer` (will also avoid duplicating code in the implementations).
* Used properties for `ScopeManager.active`, `Scope.span` and others, to mimic what we have right now in the API (`Span.context`, `Span.tracer`, etc).

Decided to iterate on a different PR as @palazzem seems to be very busy himself, and we will most likely iterate faster over here ;)

Also, PR of the actual implementation code: https://github.com/opentracing/basictracer-python/pull/25

**Update 1**: Mention that `start_span()` will implicitly use the active `Span` as the parent, if any.

cc @yurishkuro @clutchski @wkiser @itsderek23 