### PR TITLE
Update MockTracer to use the Scopes API.

### DIFF
--- a/opentracing/ext/scope.py
+++ b/opentracing/ext/scope.py
@@ -1,0 +1,51 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+from opentracing import Scope
+
+
+class ThreadLocalScope(Scope):
+    """ThreadLocalScope is an implementation of `opentracing.Scope`
+    using thread-local storage."""
+
+    def __init__(self, manager, span, finish_on_close):
+        """Initialize a `Scope` for the given `Span` object.
+
+        :param span: the `Span` wrapped by this `Scope`.
+        :param finish_on_close: whether span should automatically be
+            finished when `Scope#close()` is called.
+        """
+        super(ThreadLocalScope, self).__init__(manager, span)
+        self._finish_on_close = finish_on_close
+        self._to_restore = manager.active
+
+    def close(self):
+        """Mark the end of the active period for this {@link Scope},
+        updating ScopeManager#active in the process.
+        """
+        if self.manager.active is not self:
+            return
+
+        if self._finish_on_close:
+            self.span.finish()
+
+        setattr(self._manager._tls_scope, 'active', self._to_restore)

--- a/opentracing/ext/scope_manager.py
+++ b/opentracing/ext/scope_manager.py
@@ -1,0 +1,63 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import threading
+
+from opentracing import ScopeManager
+
+from .scope import ThreadLocalScope
+
+
+class ThreadLocalScopeManager(ScopeManager):
+    """ScopeManager implementation that stores the current active `Scope`
+    using thread-local storage.
+    """
+    def __init__(self):
+        self._tls_scope = threading.local()
+
+    def activate(self, span, finish_on_close):
+        """Make a `Span` instance active.
+
+        :param span: the `Span` that should become active.
+        :param finish_on_close: whether span should automatically be
+            finished when `Scope#close()` is called.
+
+        :return: a `Scope` instance to control the end of the active period for
+            the `Span`. It is a programming error to neglect to call
+            `Scope#close()` on the returned instance.
+        """
+        scope = ThreadLocalScope(self, span, finish_on_close)
+        setattr(self._tls_scope, 'active', scope)
+        return scope
+
+    @property
+    def active(self):
+        """Return the currently active `Scope` which can be used to access the
+        currently active `Scope#span`.
+
+        If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
+        parent of any newly-created `Span` at `Tracer#start_span()`/
+        `Tracer#start_active_span()` time.
+
+        :return: the `Scope` that is active, or `None` if not available.
+        """
+        return getattr(self._tls_scope, 'active', None)

--- a/tests/ext/test_scope.py
+++ b/tests/ext/test_scope.py
@@ -1,0 +1,59 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+import mock
+
+from opentracing.span import Span
+from opentracing.ext.scope_manager import ThreadLocalScopeManager
+
+
+def test_ext_scope_implicit_stack():
+    scope_manager = ThreadLocalScopeManager()
+
+    background_span = mock.MagicMock(spec=Span)
+    foreground_span = mock.MagicMock(spec=Span)
+
+    with scope_manager.activate(background_span, True) as background_scope:
+        assert background_scope is not None
+
+        # Activate a new Scope on top of the background one.
+        with scope_manager.activate(foreground_span, True) as foreground_scope:
+            assert foreground_scope is not None
+            assert scope_manager.active is foreground_scope
+
+        # And now the background_scope should be reinstated.
+        assert scope_manager.active is background_scope
+
+    assert background_span.finish.call_count == 1
+    assert foreground_span.finish.call_count == 1
+
+    assert scope_manager.active is None
+
+
+def test_when_different_span_is_active():
+    scope_manager = ThreadLocalScopeManager()
+
+    span = mock.MagicMock(spec=Span)
+    active = scope_manager.activate(span, False)
+    scope_manager.activate(mock.MagicMock(spec=Span), False)
+    active.close()
+
+    assert span.finish.call_count == 0

--- a/tests/ext/test_scope_manager.py
+++ b/tests/ext/test_scope_manager.py
@@ -1,0 +1,62 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+import mock
+
+from opentracing.tracer import Tracer
+from opentracing.ext.scope_manager import ThreadLocalScopeManager
+
+
+def test_ext_scope_manager_missing_active():
+    scope_manager = ThreadLocalScopeManager()
+    assert scope_manager.active is None
+
+
+def test_ext_scope_manager_activate():
+    scope_manager = ThreadLocalScopeManager()
+    tracer = Tracer()
+    span = tracer.start_span('test')
+
+    with mock.patch.object(span, 'finish') as finish:
+        scope = scope_manager.activate(span, False)
+        assert scope is not None
+        assert scope_manager.active is scope
+
+        scope.close()
+        assert finish.call_count == 0
+
+    assert scope_manager.active is None
+
+
+def test_ext_scope_manager_finish_close():
+    scope_manager = ThreadLocalScopeManager()
+    tracer = Tracer()
+    span = tracer.start_span('test')
+
+    with mock.patch.object(span, 'finish') as finish:
+        scope = scope_manager.activate(span, True)
+        assert scope is not None
+        assert scope_manager.active is scope
+
+        scope.close()
+        assert finish.call_count == 1
+
+    assert scope_manager.active is None


### PR DESCRIPTION
This includes ThreadLocalScopeManager in the `ext`
submodule.

Wondering if we should import `ThreadLocalScopeManager` by default, so instead of

```python
from opentracing.ext.scope_manager import ThreadLocalScopeManager
```

we do:

```python
from opentracing.ext import ThreadLocalScopeManager
```

@yurishkuro @palazzem 