### PR TITLE
Fix some v2.0.0 docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ History
 1.2.1 (2016-09-22)
 ------------------
 
-- Make Span.log(self, **kwargs) smarter
+- Make Span.log(self, \**kwargs) smarter
 
 
 1.2.0 (2016-09-21)
@@ -115,7 +115,7 @@ History
 ------------------
 
 - Change inheritance to match api-go: TraceContextSource extends codecs,
-Tracer extends TraceContextSource
+  Tracer extends TraceContextSource
 - Create API harness
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ master_doc = 'index'
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_static_path = ['_static']
+html_static_path = []
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 intersphinx_mapping = {

--- a/opentracing/ext/scope.py
+++ b/opentracing/ext/scope.py
@@ -31,16 +31,16 @@ class ThreadLocalScope(Scope):
         """Initialize a `Scope` for the given `Span` object.
 
         :param span: the `Span` wrapped by this `Scope`.
-        :param finish_on_close: whether span should automatically be
-            finished when `Scope#close()` is called.
+        :param finish_on_close: whether :class:`Span` should automatically be
+            finished when :meth:`Scope.close()` is called.
         """
         super(ThreadLocalScope, self).__init__(manager, span)
         self._finish_on_close = finish_on_close
         self._to_restore = manager.active
 
     def close(self):
-        """Mark the end of the active period for this {@link Scope},
-        updating ScopeManager#active in the process.
+        """Mark the end of the active period for this :class:`Scope`,
+        updating :attr:`ScopeManager.active` in the process.
         """
         if self.manager.active is not self:
             return

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 class UnsupportedFormatException(Exception):
     """UnsupportedFormatException should be used when the provided format
-    value is unknown or disallowed by the Tracer.
+    value is unknown or disallowed by the tracer.
 
     See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
@@ -69,21 +69,21 @@ class Format(object):
 
     TEXT_MAP = 'text_map'
     """
-    The TEXT_MAP format represents SpanContexts in a python dict mapping from
+    The TEXT_MAP format represents span contexts in a python dict mapping from
     strings to strings.
 
     Both the keys and the values have unrestricted character sets (unlike the
     HTTP_HEADERS format).
 
     NOTE: The TEXT_MAP carrier dict may contain unrelated data (e.g.,
-    arbitrary gRPC metadata). As such, the Tracer implementation should use a
-    prefix or other convention to distinguish Tracer-specific key:value
+    arbitrary gRPC metadata). As such, the tracer implementation should use a
+    prefix or other convention to distinguish tracer-specific key:value
     pairs.
     """
 
     HTTP_HEADERS = 'http_headers'
     """
-    The HTTP_HEADERS format represents SpanContexts in a python dict mapping
+    The HTTP_HEADERS format represents span contexts in a python dict mapping
     from character-restricted strings to strings.
 
     Keys and values in the HTTP_HEADERS carrier must be suitable for use as
@@ -93,7 +93,7 @@ class Format(object):
     URL-escaped.
 
     NOTE: The HTTP_HEADERS carrier dict may contain unrelated data (e.g.,
-    arbitrary gRPC metadata). As such, the Tracer implementation should use a
-    prefix or other convention to distinguish Tracer-specific key:value
+    arbitrary gRPC metadata). As such, the tracer implementation should use a
+    prefix or other convention to distinguish tracer-specific key:value
     pairs.
     """

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -25,7 +25,7 @@ class UnsupportedFormatException(Exception):
     """UnsupportedFormatException should be used when the provided format
     value is unknown or disallowed by the Tracer.
 
-    See Tracer.inject() and Tracer.extract().
+    See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
     pass
 
@@ -34,7 +34,7 @@ class InvalidCarrierException(Exception):
     """InvalidCarrierException should be used when the provided carrier
     instance does not match what the `format` argument requires.
 
-    See Tracer.inject() and Tracer.extract().
+    See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
     pass
 
@@ -43,7 +43,7 @@ class SpanContextCorruptedException(Exception):
     """SpanContextCorruptedException should be used when the underlying span
     context state is seemingly present but not well-formed.
 
-    See Tracer.inject() and Tracer.extract().
+    See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
     pass
 
@@ -51,8 +51,8 @@ class SpanContextCorruptedException(Exception):
 class Format(object):
     """A namespace for builtin carrier formats.
 
-    These static constants are intended for use in the Tracer.inject() and
-    Tracer.extract() methods. E.g.::
+    These static constants are intended for use in the :meth:`Tracer.inject()`
+    and :meth:`Tracer.extract()` methods. E.g.::
 
         tracer.inject(span.context, Format.BINARY, binary_carrier)
 
@@ -62,9 +62,9 @@ class Format(object):
     """
     The BINARY format represents SpanContexts in an opaque bytearray carrier.
 
-    For both Tracer.inject() and Tracer.extract() the carrier should be a
-    bytearray instance. Tracer.inject() must append to the bytearray carrier
-    (rather than replace its contents).
+    For both :meth:`Tracer.inject()` and :meth:`Tracer.extract()` the carrier
+    should be a bytearray instance. :meth:`Tracer.inject()` must append to the
+    bytearray carrier (rather than replace its contents).
     """
 
     TEXT_MAP = 'text_map'

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 class UnsupportedFormatException(Exception):
     """UnsupportedFormatException should be used when the provided format
-    value is unknown or disallowed by the tracer.
+    value is unknown or disallowed by the :class:`Tracer`.
 
     See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
@@ -40,8 +40,8 @@ class InvalidCarrierException(Exception):
 
 
 class SpanContextCorruptedException(Exception):
-    """SpanContextCorruptedException should be used when the underlying span
-    context state is seemingly present but not well-formed.
+    """SpanContextCorruptedException should be used when the underlying
+    :class:`SpanContext` state is seemingly present but not well-formed.
 
     See :meth:`Tracer.inject()` and :meth:`Tracer.extract()`.
     """
@@ -69,22 +69,22 @@ class Format(object):
 
     TEXT_MAP = 'text_map'
     """
-    The TEXT_MAP format represents span contexts in a python dict mapping from
-    strings to strings.
+    The TEXT_MAP format represents :class:`SpanContext`\ s in a python ``dict``
+    mapping from strings to strings.
 
     Both the keys and the values have unrestricted character sets (unlike the
     HTTP_HEADERS format).
 
-    NOTE: The TEXT_MAP carrier dict may contain unrelated data (e.g.,
-    arbitrary gRPC metadata). As such, the tracer implementation should use a
-    prefix or other convention to distinguish tracer-specific key:value
-    pairs.
+    NOTE: The TEXT_MAP carrier ``dict`` may contain unrelated data (e.g.,
+    arbitrary gRPC metadata). As such, the :class:`Tracer` implementation
+    should use a prefix or other convention to distinguish tracer-specific
+    key:value pairs.
     """
 
     HTTP_HEADERS = 'http_headers'
     """
-    The HTTP_HEADERS format represents span contexts in a python dict mapping
-    from character-restricted strings to strings.
+    The HTTP_HEADERS format represents :class:`SpanContext`\ s in a python
+    ``dict`` mapping from character-restricted strings to strings.
 
     Keys and values in the HTTP_HEADERS carrier must be suitable for use as
     HTTP headers (without modification or further escaping). That is, the
@@ -92,8 +92,8 @@ class Format(object):
     be preserved by various intermediaries, and the values should be
     URL-escaped.
 
-    NOTE: The HTTP_HEADERS carrier dict may contain unrelated data (e.g.,
-    arbitrary gRPC metadata). As such, the tracer implementation should use a
-    prefix or other convention to distinguish tracer-specific key:value
-    pairs.
+    NOTE: The HTTP_HEADERS carrier ``dict`` may contain unrelated data (e.g.,
+    arbitrary gRPC metadata). As such, the :class:`Tracer` implementation
+    should use a prefix or other convention to distinguish tracer-specific
+    key:value pairs.
     """

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -24,11 +24,11 @@ from __future__ import absolute_import
 class Scope(object):
     """A `Scope` formalizes the activation and deactivation of a `Span`,
     usually from a CPU standpoint. Many times a `Span` will be extant (in that
-    :meth:`Span.finish()` has not been called) despite being in a non-runnable state
-    from a CPU/scheduler standpoint. For instance, a ``Span`` representing the
-    client side of an RPC will be unfinished but blocked on IO while the RPC is
-    still outstanding. A ``Scope`` defines when a given ``Span`` is scheduled
-    and on the path.
+    :meth:`Span.finish()` has not been called) despite being in a non-runnable
+    state from a CPU/scheduler standpoint. For instance, a ``Span``
+    representing the client side of an RPC will be unfinished but blocked on IO
+    while the RPC is still outstanding. A ``Scope`` defines when a given
+    ``Span`` is scheduled and on the path.
     """
     def __init__(self, manager, span):
         """Initializes a ``Scope`` for the given ``Span`` object.

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -22,18 +22,18 @@ from __future__ import absolute_import
 
 
 class Scope(object):
-    """A scope formalizes the activation and deactivation of a span, usually
-    from a CPU standpoint. Many times a span will be extant (in that
-    :meth:`Span.finish()` has not been called) despite being in a non-runnable
-    state from a CPU/scheduler standpoint. For instance, a span representing
-    the client side of an RPC will be unfinished but blocked on IO while the
-    RPC is still outstanding. A scope defines when a given span is scheduled
-    and on the path.
+    """A scope formalizes the activation and deactivation of a :class:`Span`,
+    usually from a CPU standpoint. Many times a :class:`Span` will be extant
+    (in that :meth:`Span.finish()` has not been called) despite being in a
+    non-runnable state from a CPU/scheduler standpoint. For instance, a
+    :class:`Span` representing the client side of an RPC will be unfinished but
+    blocked on IO while the RPC is still outstanding. A scope defines when a
+    given :class:`Span` is scheduled and on the path.
 
-    :param manager: the scope manager that created this scope.
+    :param manager: the :class:`ScopeManager` that created this :class:`Scope`.
     :type manager: ScopeManager
 
-    :param span: the span used for this scope.
+    :param span: the :class:`Span` used for this :class:`Scope`.
     :type span: Span
     """
     def __init__(self, manager, span):
@@ -43,7 +43,7 @@ class Scope(object):
 
     @property
     def span(self):
-        """Returns the span wrapped by this scope.
+        """Returns the :class:`Span` wrapped by this :class:`Scope`.
 
         :rtype: Span
         """
@@ -51,18 +51,18 @@ class Scope(object):
 
     @property
     def manager(self):
-        """Returns the scope manager that created this scope.
+        """Returns the :class:`ScopeManager` that created this :class:`Scope`.
 
         :rtype: ScopeManager
         """
         return self._manager
 
     def close(self):
-        """Marks the end of the active period for this scope, updating
+        """Marks the end of the active period for this :class:`Scope`, updating
         :attr:`ScopeManager.active` in the process.
 
-        NOTE: Calling this method more than once on a single scope leads to
-        undefined behavior.
+        NOTE: Calling this method more than once on a single :class:`Scope`
+        leads to undefined behavior.
         """
         pass
 

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -24,17 +24,17 @@ from __future__ import absolute_import
 class Scope(object):
     """A `Scope` formalizes the activation and deactivation of a `Span`,
     usually from a CPU standpoint. Many times a `Span` will be extant (in that
-    `Span#finish()` has not been called) despite being in a non-runnable state
-    from a CPU/scheduler standpoint. For instance, a `Span` representing the
+    :meth:`Span.finish()` has not been called) despite being in a non-runnable state
+    from a CPU/scheduler standpoint. For instance, a ``Span`` representing the
     client side of an RPC will be unfinished but blocked on IO while the RPC is
-    still outstanding. A `Scope` defines when a given `Span` is scheduled
+    still outstanding. A ``Scope`` defines when a given ``Span`` is scheduled
     and on the path.
     """
     def __init__(self, manager, span):
-        """Initializes a `Scope` for the given `Span` object.
+        """Initializes a ``Scope`` for the given ``Span`` object.
 
-        :param manager: the `ScopeManager` that created this `Scope`
-        :param span: the `Span` used for this `Scope`
+        :param manager: the ``ScopeManager`` that created this ``Scope``
+        :param span: the ``Span`` used for this ``Scope``
         """
         self._manager = manager
         self._span = span

--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -22,39 +22,47 @@ from __future__ import absolute_import
 
 
 class Scope(object):
-    """A `Scope` formalizes the activation and deactivation of a `Span`,
-    usually from a CPU standpoint. Many times a `Span` will be extant (in that
+    """A scope formalizes the activation and deactivation of a span, usually
+    from a CPU standpoint. Many times a span will be extant (in that
     :meth:`Span.finish()` has not been called) despite being in a non-runnable
-    state from a CPU/scheduler standpoint. For instance, a ``Span``
-    representing the client side of an RPC will be unfinished but blocked on IO
-    while the RPC is still outstanding. A ``Scope`` defines when a given
-    ``Span`` is scheduled and on the path.
+    state from a CPU/scheduler standpoint. For instance, a span representing
+    the client side of an RPC will be unfinished but blocked on IO while the
+    RPC is still outstanding. A scope defines when a given span is scheduled
+    and on the path.
+
+    :param manager: the scope manager that created this scope.
+    :type manager: ScopeManager
+
+    :param span: the span used for this scope.
+    :type span: Span
     """
     def __init__(self, manager, span):
-        """Initializes a ``Scope`` for the given ``Span`` object.
-
-        :param manager: the ``ScopeManager`` that created this ``Scope``
-        :param span: the ``Span`` used for this ``Scope``
-        """
+        """Initializes a scope for *span*."""
         self._manager = manager
         self._span = span
 
     @property
     def span(self):
-        """Returns the `Span` wrapped by this `Scope`."""
+        """Returns the span wrapped by this scope.
+
+        :rtype: Span
+        """
         return self._span
 
     @property
     def manager(self):
-        """Returns the `ScopeManager` that created this `Scope`."""
+        """Returns the scope manager that created this scope.
+
+        :rtype: ScopeManager
+        """
         return self._manager
 
     def close(self):
-        """Marks the end of the active period for this `Scope`,
-        updating `ScopeManager#active` in the process.
+        """Marks the end of the active period for this scope, updating
+        :attr:`ScopeManager.active` in the process.
 
-        NOTE: Calling `close()` more than once on a single `Scope` instance
-        leads to undefined behavior.
+        NOTE: Calling this method more than once on a single scope leads to
+        undefined behavior.
         """
         pass
 
@@ -63,7 +71,7 @@ class Scope(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Calls `close()` when the execution is outside the Python
+        """Calls :meth:`close()` when the execution is outside the Python
         Context Manager.
         """
         self.close()

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -25,9 +25,8 @@ from .scope import Scope
 
 
 class ScopeManager(object):
-    """The `ScopeManager` interface abstracts both the activation of `Span`
-    instances (via :meth:`ScopeManager.activate()`) and access to an active
-    `Span` / `Scope` (via :meth:`ScopeManager.active`).
+    """The :class:`ScopeManager` interface abstracts both the activation of
+    a span and access to an active span/scope.
     """
     def __init__(self):
         # TODO: `tracer` should not be None, but we don't have a reference;
@@ -37,27 +36,29 @@ class ScopeManager(object):
         self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close):
-        """Makes a `Span` instance active.
+        """Makes a span active.
 
-        :param span: the `Span` that should become active.
+        :param span: the span that should become active.
         :param finish_on_close: whether span should be automatically
             finished when :meth:`Scope.close()` is called.
 
-        :return: a `Scope` instance to control the end of the active period for
-            the `Span`. It is a programming error to neglect to call
-            :meth:`Scope.close()` on the returned instance.
+        :rtype: Scope
+        :return: a scope to control the end of the active period for *span*. It
+            is a programming error to neglect to call :meth:`Scope.close()` on
+            the returned instance.
         """
         return self._noop_scope
 
     @property
     def active(self):
-        """Returns the currently active `Scope` which can be used to access the
-        currently active `Scope.span`.
+        """Returns the currently active scope which can be used to access the
+        currently active :attr:`Scope.span`.
 
-        If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
-        parent of any newly-created `Span` at
-        :meth:`Tracer.start_active_span()` time.
+        If there is a non-null scope, its wrapped span becomes an implicit
+        parent of any newly-created span at :meth:`Tracer.start_active_span()`
+        time.
 
-        :return: the `Scope` that is active, or `None` if not available.
+        :rtype: Scope
+        :return: the scope that is active, or ``None`` if not available.
         """
         return self._noop_scope

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -26,8 +26,8 @@ from .scope import Scope
 
 class ScopeManager(object):
     """The `ScopeManager` interface abstracts both the activation of `Span`
-    instances (via `ScopeManager#activate(span, finish_on_close)`) and
-    access to an active `Span` / `Scope` (via `ScopeManager#active`).
+    instances (via :meth:`ScopeManager.activate()`) and access to an active
+    `Span` / `Scope` (via :meth:`ScopeManager.active`).
     """
     def __init__(self):
         # TODO: `tracer` should not be None, but we don't have a reference;
@@ -41,22 +41,22 @@ class ScopeManager(object):
 
         :param span: the `Span` that should become active.
         :param finish_on_close: whether span should be automatically
-            finished when `Scope#close()` is called.
+            finished when :meth:`Scope.close()` is called.
 
         :return: a `Scope` instance to control the end of the active period for
             the `Span`. It is a programming error to neglect to call
-            `Scope#close()` on the returned instance.
+            :meth:`Scope.close()` on the returned instance.
         """
         return self._noop_scope
 
     @property
     def active(self):
         """Returns the currently active `Scope` which can be used to access the
-        currently active `Scope#span`.
+        currently active `Scope.span`.
 
         If there is a non-null `Scope`, its wrapped `Span` becomes an implicit
-        parent of any newly-created `Span` at `Tracer#start_active_span()`
-        time.
+        parent of any newly-created `Span` at
+        :meth:`Tracer.start_active_span()` time.
 
         :return: the `Scope` that is active, or `None` if not available.
         """

--- a/opentracing/scope_manager.py
+++ b/opentracing/scope_manager.py
@@ -26,7 +26,7 @@ from .scope import Scope
 
 class ScopeManager(object):
     """The :class:`ScopeManager` interface abstracts both the activation of
-    a span and access to an active span/scope.
+    a :class:`Span` and access to an active :class:`Span`/:class:`Scope`.
     """
     def __init__(self):
         # TODO: `tracer` should not be None, but we don't have a reference;
@@ -36,29 +36,30 @@ class ScopeManager(object):
         self._noop_scope = Scope(self, self._noop_span)
 
     def activate(self, span, finish_on_close):
-        """Makes a span active.
+        """Makes a :class:`Span` active.
 
-        :param span: the span that should become active.
-        :param finish_on_close: whether span should be automatically
+        :param span: the :class:`Span` that should become active.
+        :param finish_on_close: whether :class:`Span` should be automatically
             finished when :meth:`Scope.close()` is called.
 
         :rtype: Scope
-        :return: a scope to control the end of the active period for *span*. It
-            is a programming error to neglect to call :meth:`Scope.close()` on
-            the returned instance.
+        :return: a :class:`Scope` to control the end of the active period for
+            *span*. It is a programming error to neglect to call
+            :meth:`Scope.close()` on the returned instance.
         """
         return self._noop_scope
 
     @property
     def active(self):
-        """Returns the currently active scope which can be used to access the
+        """Returns the currently active :class:`Scope` which can be used to access the
         currently active :attr:`Scope.span`.
 
-        If there is a non-null scope, its wrapped span becomes an implicit
-        parent of any newly-created span at :meth:`Tracer.start_active_span()`
-        time.
+        If there is a non-null :class:`Scope`, its wrapped :class:`Span`
+        becomes an implicit parent of any newly-created :class:`Span` at
+        :meth:`Tracer.start_active_span()` time.
 
         :rtype: Scope
-        :return: the scope that is active, or ``None`` if not available.
+        :return: the :class:`Scope` that is active, or ``None`` if not
+            available.
         """
         return self._noop_scope

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -24,14 +24,14 @@ from __future__ import absolute_import
 
 
 class SpanContext(object):
-    """SpanContext represents Span state that must propagate to descendant
-    Spans and across process boundaries.
+    """SpanContext represents span state that must propagate to descendant
+    spans and across process boundaries.
 
     SpanContext is logically divided into two pieces: the user-level "Baggage"
     (see :meth:`Span.set_baggage_item` and :meth:`Span.get_baggage_item`) that
-    propagates across Span boundaries and any Tracer-implementation-specific
+    propagates across span boundaries and any tracer-implementation-specific
     fields that are needed to identify or otherwise contextualize the
-    associated Span instance (e.g., a <trace_id, span_id, sampled> tuple).
+    associated span (e.g., a ``(trace_id, span_id, sampled)`` tuple).
     """
 
     EMPTY_BAGGAGE = {}  # TODO would be nice to make this immutable
@@ -39,7 +39,7 @@ class SpanContext(object):
     @property
     def baggage(self):
         """
-        Return baggage associated with this SpanContext.
+        Return baggage associated with this span context.
         If no baggage has been added to the span, returns an empty dict.
 
         The caller must not modify the returned dictionary.
@@ -48,7 +48,7 @@ class SpanContext(object):
         :meth:`Span.get_baggage_item()`
 
         :rtype: dict
-        :return: baggage associated with this SpanContext or {}.
+        :return: baggage associated with this span context or ``{}``.
         """
         return SpanContext.EMPTY_BAGGAGE
 
@@ -61,12 +61,12 @@ class Span(object):
     and these relationships transitively form a DAG. It is common for spans to
     have at most one parent, and thus most traces are merely tree structures.
 
-    Span implements a Context Manager API that allows the following usage::
+    Span implements a context manager API that allows the following usage::
 
         with tracer.start_span(operation_name='go_fishing') as span:
             call_some_service()
 
-    In the Context Manager syntax it's not necessary to call
+    In the context manager syntax it's not necessary to call
     :meth:`Span.finish()`
     """
 
@@ -76,20 +76,22 @@ class Span(object):
 
     @property
     def context(self):
-        """Provides access to the SpanContext associated with this Span.
+        """Provides access to the span context associated with this span.
 
-        The SpanContext contains state that propagates from Span to Span in a
+        The span context contains state that propagates from span to span in a
         larger trace.
 
-        :return: the SpanContext associated with this Span.
+        :rtype: SpanContext
+        :return: the span context associated with this span.
         """
         return self._context
 
     @property
     def tracer(self):
-        """Provides access to the Tracer that created this Span.
+        """Provides access to the tracer that created this span.
 
-        :return: the Tracer that created this Span.
+        :rtype: Tracer
+        :return: the tracer that created this span.
         """
         return self._tracer
 
@@ -97,7 +99,10 @@ class Span(object):
         """Changes the operation name.
 
         :param operation_name: the new operation name
-        :return: the Span itself, for call chaining.
+        :type operation_name: str
+
+        :rtype: Span
+        :return: the span itself, for call chaining.
         """
         return self
 
@@ -106,10 +111,11 @@ class Span(object):
         terminated.
 
         With the exception of the `Span.context` property, the semantics of all
-        other Span methods are undefined after `finish()` has been invoked.
+        other span methods are undefined after `finish()` has been invoked.
 
-        :param finish_time: an explicit Span finish timestamp as a unix
-            timestamp per time.time()
+        :param finish_time: an explicit span finish timestamp as a unix
+            timestamp per :meth:`time.time()`
+        :type finish_time: float
         """
         pass
 
@@ -124,15 +130,18 @@ class Span(object):
         value, or pick one randomly, or even keep all of them.
 
         :param key: key or name of the tag. Must be a string.
+        :type key: str
+
         :param value: value of the tag.
+        :type value: string or bool or int or float
 
         :rtype: Span
-        :return: the Span itself, for call chaining.
+        :return: the span itself, for call chaining.
         """
         return self
 
     def log_kv(self, key_values, timestamp=None):
-        """Adds a log record to the Span.
+        """Adds a log record to the span.
 
         For example::
 
@@ -145,8 +154,8 @@ class Span(object):
         :param key_values: A dict of string keys and values of any type
         :type key_values: dict
 
-        :param timestamp: A unix timestamp per time.time(); current time if
-            None
+        :param timestamp: A unix timestamp per :meth:`time.time()`; current
+            time if ``None``
         :type timestamp: float
 
         :rtype: Span
@@ -162,7 +171,7 @@ class Span(object):
         request execution throughout the system.
 
         Note 1: Baggage is only propagated to the future (recursive) children
-        of this Span.
+        of this span.
 
         Note 2: Baggage is sent in-band with every subsequent local and remote
         calls, so this feature must be used with care.
@@ -179,13 +188,13 @@ class Span(object):
         return self
 
     def get_baggage_item(self, key):
-        """Retrieves value of the Baggage item with the given key.
+        """Retrieves value of the baggage item with the given key.
 
-        :param key: key of the Baggage item
+        :param key: key of the baggage item
         :type key: str
 
         :rtype: str
-        :return: value of the Baggage item with given key, or None.
+        :return: value of the baggage item with given key, or ``None``.
         """
         return None
 

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -44,7 +44,8 @@ class SpanContext(object):
 
         The caller must not modify the returned dictionary.
 
-        See also: :meth:`Span.set_baggage_item()` / :meth:`Span.get_baggage_item()`
+        See also: :meth:`Span.set_baggage_item()` /
+        :meth:`Span.get_baggage_item()`
 
         :rtype: dict
         :return: baggage associated with this SpanContext or {}.

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -28,10 +28,10 @@ class SpanContext(object):
     Spans and across process boundaries.
 
     SpanContext is logically divided into two pieces: the user-level "Baggage"
-    (see set_baggage_item and get_baggage_item) that propagates across Span
-    boundaries and any Tracer-implementation-specific fields that are needed to
-    identify or otherwise contextualize the associated Span instance (e.g., a
-    <trace_id, span_id, sampled> tuple).
+    (see :meth:`Span.set_baggage_item` and :meth:`Span.get_baggage_item`) that
+    propagates across Span boundaries and any Tracer-implementation-specific
+    fields that are needed to identify or otherwise contextualize the
+    associated Span instance (e.g., a <trace_id, span_id, sampled> tuple).
     """
 
     EMPTY_BAGGAGE = {}  # TODO would be nice to make this immutable
@@ -44,10 +44,10 @@ class SpanContext(object):
 
         The caller must not modify the returned dictionary.
 
-        See also: Span.set_baggage_item() / Span.get_baggage_item()
+        See also: :meth:`Span.set_baggage_item()` / :meth:`Span.get_baggage_item()`
 
         :rtype: dict
-        :return: returns baggage associated with this SpanContext or {}.
+        :return: baggage associated with this SpanContext or {}.
         """
         return SpanContext.EMPTY_BAGGAGE
 
@@ -60,14 +60,13 @@ class Span(object):
     and these relationships transitively form a DAG. It is common for spans to
     have at most one parent, and thus most traces are merely tree structures.
 
-    Span implements a Context Manager API that allows the following usage:
-
-    .. code-block:: python
+    Span implements a Context Manager API that allows the following usage::
 
         with tracer.start_span(operation_name='go_fishing') as span:
             call_some_service()
 
-    In the Context Manager syntax it's not necessary to call span.finish()
+    In the Context Manager syntax it's not necessary to call
+    :meth:`Span.finish()`
     """
 
     def __init__(self, tracer, context):
@@ -81,7 +80,7 @@ class Span(object):
         The SpanContext contains state that propagates from Span to Span in a
         larger trace.
 
-        :return: returns the SpanContext associated with this Span.
+        :return: the SpanContext associated with this Span.
         """
         return self._context
 
@@ -89,7 +88,7 @@ class Span(object):
     def tracer(self):
         """Provides access to the Tracer that created this Span.
 
-        :return: returns the Tracer that created this Span.
+        :return: the Tracer that created this Span.
         """
         return self._tracer
 
@@ -97,7 +96,7 @@ class Span(object):
         """Changes the operation name.
 
         :param operation_name: the new operation name
-        :return: Returns the Span itself, for call chaining.
+        :return: the Span itself, for call chaining.
         """
         return self
 
@@ -126,8 +125,8 @@ class Span(object):
         :param key: key or name of the tag. Must be a string.
         :param value: value of the tag.
 
-        :return: Returns the Span itself, for call chaining.
         :rtype: Span
+        :return: the Span itself, for call chaining.
         """
         return self
 
@@ -149,8 +148,8 @@ class Span(object):
             None
         :type timestamp: float
 
-        :return: Returns the Span itself, for call chaining.
         :rtype: Span
+        :return: the Span itself, for call chaining.
         """
         return self
 
@@ -173,7 +172,7 @@ class Span(object):
         :param value: Baggage item value
         :type value: str
 
-        :rtype : Span
+        :rtype: Span
         :return: itself, for chaining the calls.
         """
         return self
@@ -184,7 +183,7 @@ class Span(object):
         :param key: key of the Baggage item
         :type key: str
 
-        :rtype : str
+        :rtype: str
         :return: value of the Baggage item with given key, or None.
         """
         return None
@@ -192,7 +191,7 @@ class Span(object):
     def __enter__(self):
         """Invoked when span is used as a context manager.
 
-        :return: returns the Span itself
+        :return: the Span itself
         """
         return self
 

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -24,14 +24,15 @@ from __future__ import absolute_import
 
 
 class SpanContext(object):
-    """SpanContext represents span state that must propagate to descendant
-    spans and across process boundaries.
+    """SpanContext represents :class:`Span` state that must propagate to
+    descendant :class:`Span`\ s and across process boundaries.
 
     SpanContext is logically divided into two pieces: the user-level "Baggage"
     (see :meth:`Span.set_baggage_item` and :meth:`Span.get_baggage_item`) that
-    propagates across span boundaries and any tracer-implementation-specific
-    fields that are needed to identify or otherwise contextualize the
-    associated span (e.g., a ``(trace_id, span_id, sampled)`` tuple).
+    propagates across :class:`Span` boundaries and any
+    tracer-implementation-specific fields that are needed to identify or
+    otherwise contextualize the associated :class:`Span` (e.g., a ``(trace_id,
+    span_id, sampled)`` tuple).
     """
 
     EMPTY_BAGGAGE = {}  # TODO would be nice to make this immutable
@@ -39,8 +40,9 @@ class SpanContext(object):
     @property
     def baggage(self):
         """
-        Return baggage associated with this span context.
-        If no baggage has been added to the span, returns an empty dict.
+        Return baggage associated with this :class:`SpanContext`.
+        If no baggage has been added to the :class:`Span`, returns an empty
+        dict.
 
         The caller must not modify the returned dictionary.
 
@@ -48,7 +50,7 @@ class SpanContext(object):
         :meth:`Span.get_baggage_item()`
 
         :rtype: dict
-        :return: baggage associated with this span context or ``{}``.
+        :return: baggage associated with this :class:`SpanContext` or ``{}``.
         """
         return SpanContext.EMPTY_BAGGAGE
 
@@ -76,22 +78,24 @@ class Span(object):
 
     @property
     def context(self):
-        """Provides access to the span context associated with this span.
+        """Provides access to the :class:`SpanContext` associated with this
+        :class:`Span`.
 
-        The span context contains state that propagates from span to span in a
-        larger trace.
+        The :class:`SpanContext` contains state that propagates from
+        :class:`Span` to :class:`Span` in a larger trace.
 
         :rtype: SpanContext
-        :return: the span context associated with this span.
+        :return: the :class:`SpanContext` associated with this :class:`Span`.
         """
         return self._context
 
     @property
     def tracer(self):
-        """Provides access to the tracer that created this span.
+        """Provides access to the :class:`Tracer` that created this
+        :class:`Span`.
 
         :rtype: Tracer
-        :return: the tracer that created this span.
+        :return: the :class:`Tracer` that created this :class:`Span`.
         """
         return self._tracer
 
@@ -102,32 +106,34 @@ class Span(object):
         :type operation_name: str
 
         :rtype: Span
-        :return: the span itself, for call chaining.
+        :return: the :class:`Span` itself, for call chaining.
         """
         return self
 
     def finish(self, finish_time=None):
-        """Indicates that the work represented by this span has completed or
+        """Indicates that the work represented by this :class:`Span` has completed or
         terminated.
 
-        With the exception of the `Span.context` property, the semantics of all
-        other span methods are undefined after `finish()` has been invoked.
+        With the exception of the :attr:`Span.context` property, the semantics
+        of all other :class:`Span` methods are undefined after
+        :meth:`Span.finish()` has been invoked.
 
-        :param finish_time: an explicit span finish timestamp as a unix
-            timestamp per :meth:`time.time()`
+        :param finish_time: an explicit :class:`Span` finish timestamp as a
+            unix timestamp per :meth:`time.time()`
         :type finish_time: float
         """
         pass
 
     def set_tag(self, key, value):
-        """Attaches a key/value pair to the span.
+        """Attaches a key/value pair to the :class:`Span`.
 
         The value must be a string, a bool, or a numeric type.
 
         If the user calls set_tag multiple times for the same key,
-        the behavior of the tracer is undefined, i.e. it is implementation
-        specific whether the tracer will retain the first value, or the last
-        value, or pick one randomly, or even keep all of them.
+        the behavior of the :class:`Tracer` is undefined, i.e. it is
+        implementation specific whether the :class:`Tracer` will retain the
+        first value, or the last value, or pick one randomly, or even keep all
+        of them.
 
         :param key: key or name of the tag. Must be a string.
         :type key: str
@@ -136,12 +142,12 @@ class Span(object):
         :type value: string or bool or int or float
 
         :rtype: Span
-        :return: the span itself, for call chaining.
+        :return: the :class:`Span` itself, for call chaining.
         """
         return self
 
     def log_kv(self, key_values, timestamp=None):
-        """Adds a log record to the span.
+        """Adds a log record to the :class:`Span`.
 
         For example::
 
@@ -159,19 +165,19 @@ class Span(object):
         :type timestamp: float
 
         :rtype: Span
-        :return: the Span itself, for call chaining.
+        :return: the :class:`Span` itself, for call chaining.
         """
         return self
 
     def set_baggage_item(self, key, value):
-        """Stores a Baggage item in the span as a key/value pair.
+        """Stores a Baggage item in the :class:`Span` as a key/value pair.
 
         Enables powerful distributed context propagation functionality where
         arbitrary application data can be carried along the full path of
         request execution throughout the system.
 
         Note 1: Baggage is only propagated to the future (recursive) children
-        of this span.
+        of this :class:`Span`.
 
         Note 2: Baggage is sent in-band with every subsequent local and remote
         calls, so this feature must be used with care.
@@ -199,17 +205,18 @@ class Span(object):
         return None
 
     def __enter__(self):
-        """Invoked when span is used as a context manager.
+        """Invoked when :class:`Span` is used as a context manager.
 
-        :return: the Span itself
+        :rtype: Span
+        :return: the :class:`Span` itself
         """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Ends context manager and calls finish() on the span.
+        """Ends context manager and calls finish() on the :class:`Span`.
 
         If exception has occurred during execution, it is automatically added
-        as a tag to the span.
+        as a tag to the :class:`Span`.
         """
         if exc_type:
             self.log_kv({

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -53,12 +53,12 @@ class Tracer(object):
 
     @property
     def active_span(self):
-        """Provides access to the the active span. This is a shorthand for
+        """Provides access to the the active :class:`Span`. This is a shorthand for
         :attr:`Tracer.scope_manager.active.span`, and ``None`` will be
         returned if :attr:`Scope.span` is ``None``.
 
         :rtype: Span
-        :return: the active span.
+        :return: the active :class:`Span`.
         """
         scope = self._scope_manager.active
         return None if scope is None else scope.span
@@ -71,9 +71,10 @@ class Tracer(object):
                           start_time=None,
                           ignore_active_span=False,
                           finish_on_close=True):
-        """Returns a newly started and activated scope.
+        """Returns a newly started and activated :class:`Scope`.
 
-        The returned scope supports with-statement contexts. For example::
+        The returned :class:`Scope` supports with-statement contexts. For
+        example::
 
             with tracer.start_active_span('...') as scope:
                 scope.span.set_tag('http.method', 'GET')
@@ -81,8 +82,8 @@ class Tracer(object):
             # Span.finish() is called as part of scope deactivation through
             # the with statement.
 
-        It's also possible to not finish the span when the scope context
-        expires::
+        It's also possible to not finish the :class:`Span` when the
+        :class:`Scope` context expires::
 
             with tracer.start_active_span('...',
                                           finish_on_close=False) as scope:
@@ -92,37 +93,39 @@ class Tracer(object):
             # `finish_on_close` is `False`.
 
         :param operation_name: name of the operation represented by the new
-            span from the perspective of the current service.
+            :class:`Span` from the perspective of the current service.
         :type operation_name: str
 
-        :param child_of: (optional) a span or span context instance
-            representing the parent in a REFERENCE_CHILD_OF reference.  If
-            specified, the `references` parameter must be omitted.
+        :param child_of: (optional) a :class:`Span` or :class:`SpanContext`
+            instance representing the parent in a REFERENCE_CHILD_OF reference.
+            If specified, the `references` parameter must be omitted.
         :type child_of: Span or SpanContext
 
         :param references: (optional) references that identify one or more
-            parent span contexts. (See the Reference documentation for detail).
+            parent :class:`SpanContext`\ s. (See the Reference documentation
+            for detail).
         :type references: :obj:`list` of :class:`Reference`
 
-        :param tags: an optional dictionary of span tags. The caller gives up
-            ownership of that dictionary, because the tracer may use it as-is
-            to avoid extra data copying.
+        :param tags: an optional dictionary of :class:`Span` tags. The caller
+            gives up ownership of that dictionary, because the :class:`Tracer`
+            may use it as-is to avoid extra data copying.
         :type tags: dict
 
-        :param start_time: an explicit span start time as a unix timestamp per
-            :meth:`time.time()`.
+        :param start_time: an explicit :class:`Span` start time as a unix
+            timestamp per :meth:`time.time()`.
         :type start_time: float
 
         :param ignore_active_span: (optional) an explicit flag that ignores
-            the current active scope and creates a root span.
+            the current active :class:`Scope` and creates a root :class:`Span`.
         :type ignore_active_span: bool
 
-        :param finish_on_close: whether span should automatically be finished
-            when :meth:`Scope.close()` is called.
+        :param finish_on_close: whether :class:`Span` should automatically be
+            finished when :meth:`Scope.close()` is called.
         :type finish_on_close: bool
 
         :rtype: Scope
-        :return: a scope, already registered via the scope manager.
+        :return: a :class:`Scope`, already registered via the
+            :class:`ScopeManager`.
         """
         return self._noop_scope
 
@@ -133,22 +136,23 @@ class Tracer(object):
                    tags=None,
                    start_time=None,
                    ignore_active_span=False):
-        """Starts and returns a new span representing a unit of work.
+        """Starts and returns a new :class:`Span` representing a unit of work.
 
 
-        Starting a root span (a span with no causal references)::
+        Starting a root :class:`Span` (a :class:`Span` with no causal
+        references)::
 
             tracer.start_span('...')
 
 
-        Starting a child span (see also :meth:`start_child_span()`)::
+        Starting a child :class:`Span` (see also :meth:`start_child_span()`)::
 
             tracer.start_span(
                 '...',
                 child_of=parent_span)
 
 
-        Starting a child span in a more verbose way::
+        Starting a child :class:`Span` in a more verbose way::
 
             tracer.start_span(
                 '...',
@@ -156,21 +160,22 @@ class Tracer(object):
 
 
         :param operation_name: name of the operation represented by the new
-            span from the perspective of the current service.
+            :class:`Span` from the perspective of the current service.
         :type operation_name: str
 
-        :param child_of: (optional) a span or span context representing the
-            parent in a REFERENCE_CHILD_OF reference.  If specified, the
-            `references` parameter must be omitted.
+        :param child_of: (optional) a :class:`Span` or :class:`SpanContext`
+            representing the parent in a REFERENCE_CHILD_OF reference.  If
+            specified, the `references` parameter must be omitted.
         :type child_of: Span or SpanContext
 
         :param references: (optional) references that identify one or more
-            parent span contexts. (See the Reference documentation for detail).
+            parent :class:`SpanContext`\ s. (See the Reference documentation
+            for detail).
         :type references: :obj:`list` of :class:`Reference`
 
-        :param tags: an optional dictionary of span tags. The caller gives up
-            ownership of that dictionary, because the tracer may use it as-is
-            to avoid extra data copying.
+        :param tags: an optional dictionary of :class:`Span` tags. The caller
+            gives up ownership of that dictionary, because the :class:`Tracer`
+            may use it as-is to avoid extra data copying.
         :type tags: dict
 
         :param start_time: an explicit Span start time as a unix timestamp per
@@ -178,11 +183,11 @@ class Tracer(object):
         :type start_time: float
 
         :param ignore_active_span: an explicit flag that ignores the current
-            active scope and creates a root span.
+            active :class:`Scope` and creates a root :class:`Span`.
         :type ignore_active_span: bool
 
         :rtype: Span
-        :return: an already-started span instance.
+        :return: an already-started :class:`Span` instance.
         """
         return self._noop_span
 
@@ -195,7 +200,7 @@ class Tracer(object):
         Implementations *must* raise :exc:`UnsupportedFormatException` if
         `format` is unknown or disallowed.
 
-        :param span_context: the span context instance to inject
+        :param span_context: the :class:`SpanContext` instance to inject
         :type span_context: SpanContext
 
         :param format: a python object instance that represents a given
@@ -209,8 +214,9 @@ class Tracer(object):
         raise UnsupportedFormatException(format)
 
     def extract(self, format, carrier):
-        """Returns a span context instance extracted from a `carrier` of the
-        given `format`, or ``None`` if no such span context could be found.
+        """Returns a :class:`SpanContext` instance extracted from a `carrier` of the
+        given `format`, or ``None`` if no such :class:`SpanContext` could be
+        found.
 
         The type of `carrier` is determined by `format`. See the
         :class:`Format` class/namespace for the built-in OpenTracing formats.
@@ -230,8 +236,8 @@ class Tracer(object):
         :param carrier: the format-specific carrier object to extract from
 
         :rtype: SpanContext
-        :return: a span context extracted from `carrier` or ``None`` if no such
-            span context could be found.
+        :return: a :class:`SpanContext` extracted from `carrier` or ``None`` if
+            no such :class:`SpanContext` could be found.
         """
         if format in Tracer._supported_formats:
             return self._noop_span_context
@@ -251,14 +257,14 @@ class ReferenceType(object):
 # We use namedtuple since references are meant to be immutable.
 # We subclass it to expose a standard docstring.
 class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
-    """A Reference pairs a reference type with a referenced span context.
+    """A Reference pairs a reference type with a referenced :class:`SpanContext`.
 
     References are used by :meth:`Tracer.start_span()` to describe the
-    relationships between spans.
+    relationships between :class:`Span`\ s.
 
-    Tracer implementations must ignore references where referenced_context is
-    ``None``.  This behavior allows for simpler code when an inbound RPC
-    request contains no tracing information and as a result
+    :class:`Tracer` implementations must ignore references where
+    referenced_context is ``None``.  This behavior allows for simpler code when
+    an inbound RPC request contains no tracing information and as a result
     :meth:`Tracer.extract()` returns ``None``::
 
         parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
@@ -275,8 +281,9 @@ class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
 def child_of(referenced_context=None):
     """child_of is a helper that creates CHILD_OF References.
 
-    :param referenced_context: the (causal parent) span context to reference.
-        If ``None`` is passed, this reference must be ignored by the tracer.
+    :param referenced_context: the (causal parent) :class:`SpanContext` to
+        reference. If ``None`` is passed, this reference must be ignored by
+        the :class:`Tracer`.
     :type referenced_context: SpanContext
 
     :rtype: Reference
@@ -291,8 +298,9 @@ def child_of(referenced_context=None):
 def follows_from(referenced_context=None):
     """follows_from is a helper that creates FOLLOWS_FROM References.
 
-    :param referenced_context: the (causal parent) span context to reference
-        If ``None`` is passed, this reference must be ignored by the tracer.
+    :param referenced_context: the (causal parent) :class:`SpanContext` to
+        reference. If ``None`` is passed, this reference must be ignored by the
+        :class:`Tracer`.
     :type referenced_context: SpanContext
 
     :rtype: Reference
@@ -305,7 +313,8 @@ def follows_from(referenced_context=None):
 
 
 def start_child_span(parent_span, operation_name, tags=None, start_time=None):
-    """A shorthand method that starts a `child_of` span for a given parent span.
+    """A shorthand method that starts a `child_of` :class:`Span` for a given
+    parent :class:`Span`.
 
     Equivalent to calling::
 
@@ -315,24 +324,25 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
             tags=tags,
             start_time=start_time)
 
-    :param parent_span: the span which will act as the parent in the returned
-        span's child_of reference.
+    :param parent_span: the :class:`Span` which will act as the parent in the
+        returned :class:`Span`\ s child_of reference.
     :type parent_span: Span
 
-    :param operation_name: the operation name for the child span instance
+    :param operation_name: the operation name for the child :class:`Span`
+        instance
     :type operation_name: str
 
-    :param tags: optional dict of span tags. The caller gives up ownership of
-        that dict, because the tracer may use it as-is to avoid extra data
-        copying.
+    :param tags: optional dict of :class:`Span` tags. The caller gives up
+        ownership of that dict, because the :class:`Tracer` may use it as-is to
+        avoid extra data copying.
     :type tags: dict
 
-    :param start_time: an explicit span start time as a unix timestamp per
-        :meth:`time.time()`.
+    :param start_time: an explicit :class:`Span` start time as a unix timestamp
+        per :meth:`time.time()`.
     :type start_time: float
 
     :rtype: Span
-    :return: an already-started span instance.
+    :return: an already-started :class:`Span` instance.
     """
     return parent_span.tracer.start_span(
         operation_name=operation_name,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -57,7 +57,7 @@ class Tracer(object):
         Tracer.scope_manager.active.span, and None will be returned if
         Scope.span is None.
 
-        :return: returns the active Span.
+        :return: the active Span.
         """
         scope = self._scope_manager.active
         return None if scope is None else scope.span
@@ -72,7 +72,7 @@ class Tracer(object):
                           finish_on_close=True):
         """Returns a newly started and activated `Scope`.
 
-        The returned `Scope` supports with-statement contexts. For example:
+        The returned `Scope` supports with-statement contexts. For example::
 
             with tracer.start_active_span('...') as scope:
                 scope.span.set_tag('http.method', 'GET')
@@ -81,7 +81,7 @@ class Tracer(object):
             # the with statement.
 
         It's also possible to not finish the `Span` when the `Scope` context
-        expires:
+        expires::
 
             with tracer.start_active_span('...',
                                           finish_on_close=False) as scope:
@@ -108,7 +108,7 @@ class Tracer(object):
         :param finish_on_close: whether span should automatically be finished
             when `Scope#close()` is called.
 
-         :return: a `Scope`, already registered via the `ScopeManager`.
+        :return: a `Scope`, already registered via the `ScopeManager`.
         """
         return self._noop_scope
 
@@ -127,7 +127,7 @@ class Tracer(object):
             tracer.start_span('...')
 
 
-        Starting a child Span (see also start_child_span())::
+        Starting a child Span (see also `start_child_span()`)::
 
             tracer.start_span(
                 '...',
@@ -157,7 +157,7 @@ class Tracer(object):
         :param ignore_active_span: an explicit flag that ignores the current
             active `Scope` and creates a root `Span`.
 
-        :return: Returns an already-started Span instance.
+        :return: an already-started Span instance.
         """
         return self._noop_span
 
@@ -192,9 +192,9 @@ class Tracer(object):
         Implementations MUST raise opentracing.UnsupportedFormatException if
         `format` is unknown or disallowed.
 
-        Implementations may raise opentracing.InvalidCarrierException,
-        opentracing.SpanContextCorruptedException, or implementation-specific
-        errors if there are problems with `carrier`.
+        Implementations may raise :meth:`opentracing.InvalidCarrierException`,
+        :meth:`opentracing.SpanContextCorruptedException`, or
+        implementation-specific errors if there are problems with `carrier`.
 
         :param format: a python object instance that represents a given
             carrier format. `format` may be of any type, and `format` equality
@@ -224,13 +224,13 @@ class ReferenceType(object):
 class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     """A Reference pairs a reference type with a referenced SpanContext.
 
-    References are used by Tracer.start_span() to describe the relationships
-    between Spans.
+    References are used by :meth:`Tracer.start_span()` to describe the
+    relationships between Spans.
 
     Tracer implementations must ignore references where referenced_context is
     None.  This behavior allows for simpler code when an inbound RPC request
-    contains no tracing information and as a result tracer.extract() returns
-    None::
+    contains no tracing information and as a result :meth:`Tracer.extract()`
+    returns None::
 
         parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
         span = tracer.start_span(
@@ -273,7 +273,7 @@ def follows_from(referenced_context=None):
 def start_child_span(parent_span, operation_name, tags=None, start_time=None):
     """A shorthand method that starts a child_of span for a given parent span.
 
-    Equivalent to calling
+    Equivalent to calling::
 
         parent_span.tracer().start_span(
             operation_name,
@@ -290,7 +290,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
     :param start_time: an explicit Span start time as a unix timestamp per
         time.time().
 
-    :return: Returns an already-started Span instance.
+    :return: an already-started Span instance.
     """
     return parent_span.tracer.start_span(
         operation_name=operation_name,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -53,11 +53,12 @@ class Tracer(object):
 
     @property
     def active_span(self):
-        """Provides access to the the active Span. This is a shorthand for
-        Tracer.scope_manager.active.span, and None will be returned if
-        Scope.span is None.
+        """Provides access to the the active span. This is a shorthand for
+        :attr:`Tracer.scope_manager.active.span`, and ``None`` will be
+        returned if :attr:`Scope.span` is ``None``.
 
-        :return: the active ``Span``.
+        :rtype: Span
+        :return: the active span.
         """
         scope = self._scope_manager.active
         return None if scope is None else scope.span
@@ -70,17 +71,17 @@ class Tracer(object):
                           start_time=None,
                           ignore_active_span=False,
                           finish_on_close=True):
-        """Returns a newly started and activated `Scope`.
+        """Returns a newly started and activated scope.
 
-        The returned `Scope` supports with-statement contexts. For example::
+        The returned scope supports with-statement contexts. For example::
 
             with tracer.start_active_span('...') as scope:
                 scope.span.set_tag('http.method', 'GET')
                 do_some_work()
-            # Span.finish() is called as part of Scope deactivation through
+            # Span.finish() is called as part of scope deactivation through
             # the with statement.
 
-        It's also possible to not finish the `Span` when the `Scope` context
+        It's also possible to not finish the span when the scope context
         expires::
 
             with tracer.start_active_span('...',
@@ -92,23 +93,36 @@ class Tracer(object):
 
         :param operation_name: name of the operation represented by the new
             span from the perspective of the current service.
-        :param child_of: (optional) a Span or SpanContext instance representing
-            the parent in a REFERENCE_CHILD_OF Reference. If specified, the
-            `references` parameter must be omitted.
-        :param references: (optional) a list of Reference objects that identify
-            one or more parent SpanContexts. (See the Reference documentation
-            for detail).
-        :param tags: an optional dictionary of Span Tags. The caller gives up
-            ownership of that dictionary, because the Tracer may use it as-is
+        :type operation_name: str
+
+        :param child_of: (optional) a span or span context instance
+            representing the parent in a REFERENCE_CHILD_OF reference.  If
+            specified, the `references` parameter must be omitted.
+        :type child_of: Span or SpanContext
+
+        :param references: (optional) references that identify one or more
+            parent span contexts. (See the Reference documentation for detail).
+        :type references: :obj:`list` of :class:`Reference`
+
+        :param tags: an optional dictionary of span tags. The caller gives up
+            ownership of that dictionary, because the tracer may use it as-is
             to avoid extra data copying.
-        :param start_time: an explicit Span start time as a unix timestamp per
-            time.time().
+        :type tags: dict
+
+        :param start_time: an explicit span start time as a unix timestamp per
+            :meth:`time.time()`.
+        :type start_time: float
+
         :param ignore_active_span: (optional) an explicit flag that ignores
-            the current active `Scope` and creates a root `Span`.
+            the current active scope and creates a root span.
+        :type ignore_active_span: bool
+
         :param finish_on_close: whether span should automatically be finished
             when :meth:`Scope.close()` is called.
+        :type finish_on_close: bool
 
-        :return: a ``Scope``, already registered via the ``ScopeManager``.
+        :rtype: Scope
+        :return: a scope, already registered via the scope manager.
         """
         return self._noop_scope
 
@@ -119,22 +133,22 @@ class Tracer(object):
                    tags=None,
                    start_time=None,
                    ignore_active_span=False):
-        """Starts and returns a new Span representing a unit of work.
+        """Starts and returns a new span representing a unit of work.
 
 
-        Starting a root Span (a Span with no causal references)::
+        Starting a root span (a span with no causal references)::
 
             tracer.start_span('...')
 
 
-        Starting a child Span (see also `start_child_span()`)::
+        Starting a child span (see also :meth:`start_child_span()`)::
 
             tracer.start_span(
                 '...',
                 child_of=parent_span)
 
 
-        Starting a child Span in a more verbose way::
+        Starting a child span in a more verbose way::
 
             tracer.start_span(
                 '...',
@@ -143,21 +157,32 @@ class Tracer(object):
 
         :param operation_name: name of the operation represented by the new
             span from the perspective of the current service.
-        :param child_of: (optional) a Span or SpanContext instance representing
-            the parent in a REFERENCE_CHILD_OF Reference. If specified, the
-            `references` parameter must be omitted.
-        :param references: (optional) a list of Reference objects that identify
-            one or more parent SpanContexts. (See the Reference documentation
-            for detail)
-        :param tags: an optional dictionary of Span Tags. The caller gives up
-            ownership of that dictionary, because the Tracer may use it as-is
-            to avoid extra data copying.
-        :param start_time: an explicit Span start time as a unix timestamp per
-            time.time()
-        :param ignore_active_span: an explicit flag that ignores the current
-            active `Scope` and creates a root `Span`.
+        :type operation_name: str
 
-        :return: an already-started Span instance.
+        :param child_of: (optional) a span or span context representing the
+            parent in a REFERENCE_CHILD_OF reference.  If specified, the
+            `references` parameter must be omitted.
+        :type child_of: Span or SpanContext
+
+        :param references: (optional) references that identify one or more
+            parent span contexts. (See the Reference documentation for detail).
+        :type references: :obj:`list` of :class:`Reference`
+
+        :param tags: an optional dictionary of span tags. The caller gives up
+            ownership of that dictionary, because the tracer may use it as-is
+            to avoid extra data copying.
+        :type tags: dict
+
+        :param start_time: an explicit Span start time as a unix timestamp per
+            :meth:`time.time()`
+        :type start_time: float
+
+        :param ignore_active_span: an explicit flag that ignores the current
+            active scope and creates a root span.
+        :type ignore_active_span: bool
+
+        :rtype: Span
+        :return: an already-started span instance.
         """
         return self._noop_span
 
@@ -165,16 +190,18 @@ class Tracer(object):
         """Injects `span_context` into `carrier`.
 
         The type of `carrier` is determined by `format`. See the
-        opentracing.propagation.Format class/namespace for the built-in
-        OpenTracing formats.
+        :class:`Format` class/namespace for the built-in OpenTracing formats.
 
-        Implementations MUST raise opentracing.UnsupportedFormatException if
+        Implementations *must* raise :exc:`UnsupportedFormatException` if
         `format` is unknown or disallowed.
 
-        :param span_context: the SpanContext instance to inject
+        :param span_context: the span context instance to inject
+        :type span_context: SpanContext
+
         :param format: a python object instance that represents a given
             carrier format. `format` may be of any type, and `format` equality
-            is defined by python `==` equality.
+            is defined by python ``==`` equality.
+        :type format: Format
         :param carrier: the format-specific carrier object to inject into
         """
         if format in Tracer._supported_formats:
@@ -182,27 +209,29 @@ class Tracer(object):
         raise UnsupportedFormatException(format)
 
     def extract(self, format, carrier):
-        """Returns a SpanContext instance extracted from a `carrier` of the
-        given `format`, or None if no such SpanContext could be found.
+        """Returns a span context instance extracted from a `carrier` of the
+        given `format`, or ``None`` if no such span context could be found.
 
         The type of `carrier` is determined by `format`. See the
-        opentracing.propagation.Format class/namespace for the built-in
-        OpenTracing formats.
+        :class:`Format` class/namespace for the built-in OpenTracing formats.
 
-        Implementations MUST raise opentracing.UnsupportedFormatException if
+        Implementations *must* raise :exc:`UnsupportedFormatException` if
         `format` is unknown or disallowed.
 
-        Implementations may raise :meth:`opentracing.InvalidCarrierException`,
-        :meth:`opentracing.SpanContextCorruptedException`, or
-        implementation-specific errors if there are problems with `carrier`.
+        Implementations may raise :exc:`InvalidCarrierException`,
+        :exc:`SpanContextCorruptedException`, or implementation-specific errors
+        if there are problems with `carrier`.
+
 
         :param format: a python object instance that represents a given
             carrier format. `format` may be of any type, and `format` equality
-            is defined by python `==` equality.
+            is defined by python ``==`` equality.
+
         :param carrier: the format-specific carrier object to extract from
 
-        :return: a SpanContext instance extracted from `carrier` or None if no
-            such span context could be found.
+        :rtype: SpanContext
+        :return: a span context extracted from `carrier` or ``None`` if no such
+            span context could be found.
         """
         if format in Tracer._supported_formats:
             return self._noop_span_context
@@ -222,22 +251,23 @@ class ReferenceType(object):
 # We use namedtuple since references are meant to be immutable.
 # We subclass it to expose a standard docstring.
 class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
-    """A Reference pairs a reference type with a referenced SpanContext.
+    """A Reference pairs a reference type with a referenced span context.
 
     References are used by :meth:`Tracer.start_span()` to describe the
-    relationships between Spans.
+    relationships between spans.
 
     Tracer implementations must ignore references where referenced_context is
-    None.  This behavior allows for simpler code when an inbound RPC request
-    contains no tracing information and as a result :meth:`Tracer.extract()`
-    returns None::
+    ``None``.  This behavior allows for simpler code when an inbound RPC
+    request contains no tracing information and as a result
+    :meth:`Tracer.extract()` returns ``None``::
 
         parent_ref = tracer.extract(opentracing.HTTP_HEADERS, request.headers)
         span = tracer.start_span(
             'operation', references=child_of(parent_ref)
         )
 
-    See `child_of` and `follows_from` helpers for creating these references.
+    See :meth:`child_of` and :meth:`follows_from` helpers for creating these
+    references.
     """
     pass
 
@@ -245,11 +275,13 @@ class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
 def child_of(referenced_context=None):
     """child_of is a helper that creates CHILD_OF References.
 
-    :param referenced_context: the (causal parent) SpanContext to reference.
-        If None is passed, this reference must be ignored by the tracer.
+    :param referenced_context: the (causal parent) span context to reference.
+        If ``None`` is passed, this reference must be ignored by the tracer.
+    :type referenced_context: SpanContext
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_span(..., references=...)
+    :return: A reference suitable for ``Tracer.start_span(...,
+        references=...)``
     """
     return Reference(
         type=ReferenceType.CHILD_OF,
@@ -259,11 +291,13 @@ def child_of(referenced_context=None):
 def follows_from(referenced_context=None):
     """follows_from is a helper that creates FOLLOWS_FROM References.
 
-    :param referenced_context: the (causal parent) SpanContext to reference
-        If None is passed, this reference must be ignored by the tracer.
+    :param referenced_context: the (causal parent) span context to reference
+        If ``None`` is passed, this reference must be ignored by the tracer.
+    :type referenced_context: SpanContext
 
     :rtype: Reference
-    :return: A Reference suitable for Tracer.start_span(..., references=...)
+    :return: A Reference suitable for ``Tracer.start_span(...,
+        references=...)``
     """
     return Reference(
         type=ReferenceType.FOLLOWS_FROM,
@@ -271,7 +305,7 @@ def follows_from(referenced_context=None):
 
 
 def start_child_span(parent_span, operation_name, tags=None, start_time=None):
-    """A shorthand method that starts a child_of span for a given parent span.
+    """A shorthand method that starts a `child_of` span for a given parent span.
 
     Equivalent to calling::
 
@@ -281,16 +315,24 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
             tags=tags,
             start_time=start_time)
 
-    :param parent_span: the Span which will act as the parent in the returned
-        Span's child_of reference.
-    :param operation_name: the operation name for the child Span instance
-    :param tags: optional dict of Span Tags. The caller gives up ownership of
-        that dict, because the Tracer may use it as-is to avoid extra data
-        copying.
-    :param start_time: an explicit Span start time as a unix timestamp per
-        time.time().
+    :param parent_span: the span which will act as the parent in the returned
+        span's child_of reference.
+    :type parent_span: Span
 
-    :return: an already-started Span instance.
+    :param operation_name: the operation name for the child span instance
+    :type operation_name: str
+
+    :param tags: optional dict of span tags. The caller gives up ownership of
+        that dict, because the tracer may use it as-is to avoid extra data
+        copying.
+    :type tags: dict
+
+    :param start_time: an explicit span start time as a unix timestamp per
+        :meth:`time.time()`.
+    :type start_time: float
+
+    :rtype: Span
+    :return: an already-started span instance.
     """
     return parent_span.tracer.start_span(
         operation_name=operation_name,

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -57,7 +57,7 @@ class Tracer(object):
         Tracer.scope_manager.active.span, and None will be returned if
         Scope.span is None.
 
-        :return: the active Span.
+        :return: the active ``Span``.
         """
         scope = self._scope_manager.active
         return None if scope is None else scope.span
@@ -106,9 +106,9 @@ class Tracer(object):
         :param ignore_active_span: (optional) an explicit flag that ignores
             the current active `Scope` and creates a root `Span`.
         :param finish_on_close: whether span should automatically be finished
-            when `Scope#close()` is called.
+            when :meth:`Scope.close()` is called.
 
-        :return: a `Scope`, already registered via the `ScopeManager`.
+        :return: a ``Scope``, already registered via the ``ScopeManager``.
         """
         return self._noop_scope
 


### PR DESCRIPTION
Building (and reading through) the documentation revealed a number of issues:

```
...opentracing.Tracer.start_active_span:8: WARNING: Definition list ends without a blank line; unexpected unindent.
...opentracing.Tracer.start_active_span:16: WARNING: Block quote ends without a blank line; unexpected unindent.
...opentracing.Tracer.start_active_span:18: WARNING: Definition list ends without a blank line; unexpected unindent.
../CHANGELOG.rst:30: WARNING: Inline strong start-string without end-string.
../CHANGELOG.rst:118: WARNING: Bullet list ends without a blank line; unexpected unindent.
...
copying static files... WARNING: html_static_path entry u'/Users/kyle.verhoog/dev/ot-py-kyle/docs/_static' does not exist
...
build succeeded, 6 warnings.
```

This PR fixes these warnings.

This PR also attempts to:

- Use `:meth:`, `:attr:`, `:class:` and `:exc:` where possible to make navigating the docs much easier. 
- Convert mentions of instances of classes to lower case
- Use single backticks for argument names
- Use double backticks for inline code and operators
- Add argument types

@palazzem 