### PR TITLE
Add a ReadTheDocs banner to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 OpenTracing API for Python
 ==========================
 
-|GitterChat| |BuildStatus| |PyPI|
+|GitterChat| |BuildStatus| |PyPI| |ReadTheDocs|
 
 This library is a Python platform API for OpenTracing.
 
@@ -283,5 +283,6 @@ Before new release, add a summary of changes since last version to CHANGELOG.rst
    :target: https://travis-ci.org/opentracing/opentracing-python
 .. |PyPI| image:: https://badge.fury.io/py/opentracing.svg
    :target: https://badge.fury.io/py/opentracing
-
-
+.. |ReadTheDocs| image:: http://readthedocs.org/projects/opentracing-python/badge/?version=latest
+   :target: https://opentracing-python.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status


### PR DESCRIPTION
Added integration with the published API in ReadTheDocs.

* Currently using https://opentracing-python.readthedocs.io (from my personal account - can grant access to anyone who requests it).
* Currently it points by default to the last published version (1.3.0)
* Left the 1.3.0 available for-ever, in case somebody wants to see how the API worked pre-`ScopeManager` integration ;)
* Left the v2.0.0 version there, to preview what we will publish upon the 2.0 release - will remove afterwards.

@palazzem @yurishkuro @pglombardo