### PR TITLE
Fix typo in tornado scope manager documentation

### DIFF
--- a/opentracing/scope_managers/tornado.py
+++ b/opentracing/scope_managers/tornado.py
@@ -78,8 +78,8 @@ class TornadoScopeManager(ThreadLocalScopeManager):
 
             @tornado.gen.coroutine
             def handle_request_wrapper():
-                res1 = corotuine('A')
-                res2 = corotuine('B')
+                res1 = coroutine('A')
+                res2 = coroutine('B')
 
                 yield [res1, res2]
     """


### PR DESCRIPTION
As per title.