### PR TITLE
Add Flask Scope Manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,12 +201,13 @@ This project includes a set of ``ScopeManager`` implementations under the ``open
 
    from opentracing.scope_managers import ThreadLocalScopeManager
 
-There exist implementations for ``thread-local`` (the default), ``gevent``, ``Tornado`` and ``asyncio``:
+There exist implementations for ``thread-local`` (the default), ``gevent``, ``Tornado``, ``Flask``, and ``asyncio``:
 
 .. code-block:: python
 
    from opentracing.scope_managers.gevent import GeventScopeManager # requires gevent
    from opentracing.scope_managers.tornado import TornadoScopeManager # requires Tornado
+   from opentracing.scope_managers.flask import FlaskScopeManager # requires Flask
    from opentracing.scope_managers.asyncio import AsyncioScopeManager # requires Python 3.4 or newer.
 
 Development

--- a/opentracing/scope_managers/flask.py
+++ b/opentracing/scope_managers/flask.py
@@ -1,0 +1,92 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import threading
+
+from flask import _request_ctx_stack as stack
+
+from opentracing import Scope, ScopeManager
+from .constants import ACTIVE_ATTR
+
+
+class FlaskScopeManager(ScopeManager):
+    """
+    :class:`~opentracing.ScopeManager` implementation for **Flask**
+    that stores the :class:`~opentracing.Scope` in a Flask
+    :class:`RequestContext`, made accessible via
+    :attr:`flask._request_ctx_stack`.
+    """
+    def __init__(self):
+        self._tls = threading.local()
+
+    @property
+    def _context(self):
+        # Default to threading.local for usage outside
+        # app/request context (unit tests)
+        if stack.top is None:
+            return self._tls
+        return stack.top
+
+    def activate(self, span, finish_on_close):
+        """
+        Make a :class:`~opentracing.Span` instance active.
+
+        :param span: the :class:`~opentracing.Span` that should become active.
+        :param finish_on_close: whether *span* should automatically be
+            finished when :meth:`Scope.close()` is called.
+
+        :return: a :class:`~opentracing.Scope` instance to control the end
+            of the active period for the :class:`~opentracing.Span`.
+            It is a programming error to neglect to call :meth:`Scope.close()`
+            on the returned instance.
+        """
+        scope = _FlaskScope(self, span, finish_on_close)
+        setattr(self._context, ACTIVE_ATTR, scope)
+        return scope
+
+    @property
+    def active(self):
+        """
+        Return the currently active :class:`~opentracing.Scope` which
+        can be used to access the currently active
+        :attr:`Scope.span`.
+
+        :return: the :class:`~opentracing.Scope` that is active,
+            or ``None`` if not available.
+        """
+        return getattr(self._context, ACTIVE_ATTR, None)
+
+
+class _FlaskScope(Scope):
+    def __init__(self, manager, span, finish_on_close):
+        super(_FlaskScope, self).__init__(manager, span)
+        self._finish_on_close = finish_on_close
+        self._to_restore = manager.active
+
+    def close(self):
+        if self.manager.active is not self:
+            return
+
+        if self._finish_on_close:
+            self.span.finish()
+
+        setattr(self.manager._context, ACTIVE_ATTR, self._to_restore)

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
             'six>=1.10.0,<2.0',
             'gevent==1.2',
             'tornado',
+            'flask',
         ],
         ':python_version == "2.7"': ['futures'],
     },

--- a/testbed/__main__.py
+++ b/testbed/__main__.py
@@ -9,6 +9,7 @@ enabled_platforms = [
     'threads',
     'tornado',
     'gevent',
+    'flask',
 ]
 if six.PY3:
     enabled_platforms.append('asyncio')

--- a/testbed/test_active_span_replacement/test_flask.py
+++ b/testbed/test_active_span_replacement/test_flask.py
@@ -1,0 +1,49 @@
+from __future__ import print_function
+
+from flask import Flask
+
+from opentracing.scope_managers.flask import FlaskScopeManager
+from opentracing.mocktracer import MockTracer
+from ..testcase import OpenTracingTestCase
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.app = Flask(__name__)
+
+    def test_main(self):
+        # Start an isolated task and query for its result -and finish it-
+        # in another task/thread
+        span = self.tracer.start_span('initial')
+        self.submit_another_task(span)
+
+        spans = self.tracer.finished_spans()
+        self.assertEqual(len(spans), 3)
+        self.assertNamesEqual(spans, ['initial', 'subtask', 'task'])
+
+        # task/subtask are part of the same trace,
+        # and subtask is a child of task
+        self.assertSameTrace(spans[1], spans[2])
+        self.assertIsChildOf(spans[1], spans[2])
+
+        # initial task is not related in any way to those two tasks
+        self.assertNotSameTrace(spans[0], spans[1])
+        self.assertEqual(spans[0].parent_id, None)
+
+    def task(self, span):
+        # Create a new Span for this task
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('task'):
+
+                with self.tracer.scope_manager.activate(span, True):
+                    # Simulate work strictly related to the initial Span
+                    pass
+
+                # Use the task span as parent of a new subtask
+                with self.tracer.start_active_span('subtask'):
+                    pass
+
+    def submit_another_task(self, span):
+        with self.app.test_request_context():
+            self.task(span)

--- a/testbed/test_client_server/test_flask.py
+++ b/testbed/test_client_server/test_flask.py
@@ -1,0 +1,85 @@
+from __future__ import print_function
+
+from threading import Thread
+from six.moves import queue
+
+from flask import Flask
+
+import opentracing
+from opentracing.ext import tags
+from opentracing.mocktracer import MockTracer
+from opentracing.scope_managers.flask import FlaskScopeManager
+from ..testcase import OpenTracingTestCase
+from ..utils import await_until, get_logger, get_one_by_tag
+
+
+logger = get_logger(__name__)
+
+
+class Server(Thread):
+    def __init__(self, *args, **kwargs):
+        tracer = kwargs.pop('tracer')
+        queue = kwargs.pop('queue')
+        app = kwargs.pop('app')
+        super(Server, self).__init__(*args, **kwargs)
+
+        self.daemon = True
+        self.tracer = tracer
+        self.queue = queue
+        self.app = app
+
+    def run(self):
+        with self.app.test_request_context():
+            value = self.queue.get()
+            self.process(value)
+
+    def process(self, message):
+        logger.info('Processing message in server')
+
+        ctx = self.tracer.extract(opentracing.Format.TEXT_MAP, message)
+        with self.tracer.start_active_span('receive',
+                                           child_of=ctx) as scope:
+            scope.span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_SERVER)
+
+
+class Client(object):
+    def __init__(self, tracer, queue, app):
+        self.tracer = tracer
+        self.queue = queue
+        self.app = app
+
+    def send(self):
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('send') as scope:
+                scope.span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_CLIENT)
+
+                message = {}
+                self.tracer.inject(scope.span.context,
+                                   opentracing.Format.TEXT_MAP,
+                                   message)
+                self.queue.put(message)
+
+        logger.info('Sent message from client')
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.queue = queue.Queue()
+        self.app = Flask(__name__)
+        self.server = Server(tracer=self.tracer, queue=self.queue, app=self.app)
+        self.server.start()
+
+    def test(self):
+        client = Client(self.tracer, self.queue, self.app)
+        client.send()
+
+        await_until(lambda: len(self.tracer.finished_spans()) >= 2)
+
+        spans = self.tracer.finished_spans()
+        self.assertIsNotNone(get_one_by_tag(spans,
+                                            tags.SPAN_KIND,
+                                            tags.SPAN_KIND_RPC_SERVER))
+        self.assertIsNotNone(get_one_by_tag(spans,
+                                            tags.SPAN_KIND,
+                                            tags.SPAN_KIND_RPC_CLIENT))

--- a/testbed/test_common_request_handler/test_flask.py
+++ b/testbed/test_common_request_handler/test_flask.py
@@ -1,0 +1,120 @@
+from __future__ import print_function
+
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.ext import tags
+from opentracing.mocktracer import MockTracer
+from opentracing.scope_managers.flask import FlaskScopeManager
+from ..testcase import OpenTracingTestCase
+from ..utils import get_logger, get_one_by_operation_name
+from .request_handler import RequestHandler
+
+
+logger = get_logger(__name__)
+
+
+class Client(object):
+    def __init__(self, request_handler, executor, app):
+        self.request_handler = request_handler
+        self.executor = executor
+        self.app = app
+
+    def send_task(self, message):
+        request_context = {}
+
+        def before_handler():
+            with self.app.test_request_context():
+                self.request_handler.before_request(message, request_context)
+
+        def after_handler():
+            with self.app.test_request_context():
+                self.request_handler.after_request(message, request_context)
+
+        self.executor.submit(before_handler).result()
+        self.executor.submit(after_handler).result()
+
+        return '%s::response' % message
+
+    def send(self, message):
+        return self.executor.submit(self.send_task, message)
+
+    def send_sync(self, message, timeout=5.0):
+        f = self.executor.submit(self.send_task, message)
+        return f.result(timeout=timeout)
+
+
+class TestFlask(OpenTracingTestCase):
+    """
+    There is only one instance of 'RequestHandler' per 'Client'. Methods of
+    'RequestHandler' are executed concurrently in different threads which are
+    reused (executor). Therefore we cannot use current active span and
+    activate span. So one issue here is setting correct parent span.
+    """
+
+    def setUp(self):
+        self.tracer = MockTracer()
+        self.executor = ThreadPoolExecutor(max_workers=3)
+        self.app = Flask(__name__)
+        self.client = Client(RequestHandler(self.tracer), self.executor, self.app)
+
+    def test_two_callbacks(self):
+        with self.app.test_request_context():
+            response_future1 = self.client.send('message1')
+            response_future2 = self.client.send('message2')
+
+            self.assertEquals('message1::response', response_future1.result(5.0))
+            self.assertEquals('message2::response', response_future2.result(5.0))
+
+        spans = self.tracer.finished_spans()
+        self.assertEquals(len(spans), 2)
+
+        for span in spans:
+            self.assertEquals(span.tags.get(tags.SPAN_KIND, None),
+                              tags.SPAN_KIND_RPC_CLIENT)
+
+        self.assertNotSameTrace(spans[0], spans[1])
+        self.assertIsNone(spans[0].parent_id)
+        self.assertIsNone(spans[1].parent_id)
+
+    def test_parent_not_picked(self):
+        """Active parent should not be picked up by child."""
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('parent'):
+                response = self.client.send_sync('no_parent')
+                self.assertEquals('no_parent::response', response)
+
+        spans = self.tracer.finished_spans()
+        self.assertEquals(len(spans), 2)
+
+        child_span = get_one_by_operation_name(spans, 'send')
+        self.assertIsNotNone(child_span)
+
+        parent_span = get_one_by_operation_name(spans, 'parent')
+        self.assertIsNotNone(parent_span)
+
+        # Here check that there is no parent-child relation.
+        self.assertIsNotChildOf(child_span, parent_span)
+
+    def test_bad_solution_to_set_parent(self):
+        """Solution is bad because parent is per client
+        (we don't have better choice)"""
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('parent') as scope:
+                client = Client(RequestHandler(self.tracer, scope.span.context),
+                                self.executor, self.app)
+                response = client.send_sync('correct_parent')
+                self.assertEquals('correct_parent::response', response)
+
+        response = client.send_sync('wrong_parent')
+        self.assertEquals('wrong_parent::response', response)
+
+        spans = self.tracer.finished_spans()
+        self.assertEquals(len(spans), 3)
+
+        spans = sorted(spans, key=lambda x: x.start_time)
+        parent_span = get_one_by_operation_name(spans, 'parent')
+        self.assertIsNotNone(parent_span)
+
+        self.assertIsChildOf(spans[1], parent_span)
+        self.assertIsChildOf(spans[2], parent_span)

--- a/testbed/test_late_span_finish/test_flask.py
+++ b/testbed/test_late_span_finish/test_flask.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.mocktracer import MockTracer
+from ..testcase import OpenTracingTestCase
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer()
+        self.executor = ThreadPoolExecutor(max_workers=3)
+        self.app = Flask(__name__)
+
+    def test_main(self):
+        # Create a Span and use it as (explicit) parent of a pair of subtasks.
+        with self.app.test_request_context():
+            parent_span = self.tracer.start_span('parent')
+            self.submit_subtasks(parent_span)
+
+            # Wait for the threadpool to be done.
+            self.executor.shutdown(True)
+
+            # Late-finish the parent Span now.
+            parent_span.finish()
+
+        spans = self.tracer.finished_spans()
+        self.assertEqual(len(spans), 3)
+        self.assertNamesEqual(spans, ['task1', 'task2', 'parent'])
+
+        for i in range(2):
+            self.assertSameTrace(spans[i], spans[-1])
+            self.assertIsChildOf(spans[i], spans[-1])
+            self.assertTrue(spans[i].finish_time <= spans[-1].finish_time)
+
+    # Fire away a few subtasks, passing a parent Span whose lifetime
+    # is not tied at all to the children.
+    def submit_subtasks(self, parent_span):
+        def task(name, interval):
+            with self.app.test_request_context():
+                with self.tracer.scope_manager.activate(parent_span, False):
+                    with self.tracer.start_active_span(name):
+                        time.sleep(interval)
+
+        self.executor.submit(task, 'task1', 0.1)
+        self.executor.submit(task, 'task2', 0.3)

--- a/testbed/test_listener_per_request/test_flask.py
+++ b/testbed/test_listener_per_request/test_flask.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.ext import tags
+from opentracing.mocktracer import MockTracer
+from opentracing.scope_managers.flask import FlaskScopeManager
+from ..testcase import OpenTracingTestCase
+from ..utils import get_one_by_tag
+
+from .response_listener import ResponseListener
+
+
+class Client(object):
+    def __init__(self, tracer):
+        self.tracer = tracer
+        self.executor = ThreadPoolExecutor(max_workers=3)
+
+    def _task(self, message, listener):
+        res = '%s::response' % message
+        listener.on_response(res)
+        return res
+
+    def send_sync(self, message):
+        span = self.tracer.start_span('send')
+        span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_CLIENT)
+
+        listener = ResponseListener(span)
+        return self.executor.submit(self._task, message, listener).result()
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.app = Flask(__name__)
+
+    def test_main(self):
+        with self.app.test_request_context():
+            client = Client(self.tracer)
+            res = client.send_sync('message')
+            self.assertEquals(res, 'message::response')
+
+            spans = self.tracer.finished_spans()
+            self.assertEqual(len(spans), 1)
+
+        span = get_one_by_tag(spans, tags.SPAN_KIND, tags.SPAN_KIND_RPC_CLIENT)
+        self.assertIsNotNone(span)

--- a/testbed/test_multiple_callbacks/test_flask.py
+++ b/testbed/test_multiple_callbacks/test_flask.py
@@ -1,0 +1,64 @@
+from __future__ import print_function
+
+import random
+import time
+
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.scope_managers.flask import FlaskScopeManager
+from opentracing.mocktracer import MockTracer
+from ..testcase import OpenTracingTestCase
+from ..utils import RefCount, get_logger
+
+
+random.seed()
+logger = get_logger(__name__)
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.executor = ThreadPoolExecutor(max_workers=3)
+        self.app = Flask(__name__)
+
+    def test_main(self):
+        with self.app.test_request_context():
+            try:
+                scope = self.tracer.start_active_span('parent',
+                                                      finish_on_close=False)
+                scope.span._ref_count = RefCount(1)
+                self.submit_callbacks(scope.span)
+            finally:
+                scope.close()
+                if scope.span._ref_count.decr() == 0:
+                    scope.span.finish()
+
+        self.executor.shutdown(True)
+
+        spans = self.tracer.finished_spans()
+        self.assertEquals(len(spans), 4)
+        self.assertNamesEqual(spans, ['task', 'task', 'task', 'parent'])
+
+        for i in range(3):
+            self.assertSameTrace(spans[i], spans[-1])
+            self.assertIsChildOf(spans[i], spans[-1])
+
+    def task(self, interval, parent_span):
+        logger.info('Starting task')
+        with self.app.test_request_context():
+            try:
+                scope = self.tracer.scope_manager.activate(parent_span, False)
+                with self.tracer.start_active_span('task'):
+                    time.sleep(interval)
+            finally:
+                scope.close()
+                if parent_span._ref_count.decr() == 0:
+                    parent_span.finish()
+
+    def submit_callbacks(self, parent_span):
+        for i in range(3):
+            parent_span._ref_count.incr()
+            self.executor.submit(self.task,
+                                 0.1 + random.randint(200, 500) * .001,
+                                 parent_span)

--- a/testbed/test_nested_callbacks/test_flask.py
+++ b/testbed/test_nested_callbacks/test_flask.py
@@ -1,0 +1,63 @@
+from __future__ import print_function
+
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.scope_managers.flask import FlaskScopeManager
+from opentracing.mocktracer import MockTracer
+from ..testcase import OpenTracingTestCase
+from ..utils import await_until
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.executor = ThreadPoolExecutor(max_workers=3)
+        self.app = Flask(__name__)
+
+    def tearDown(self):
+        self.executor.shutdown(False)
+
+    def test_main(self):
+        # Start a Span and let the callback-chain
+        # finish it when the task is done
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('one', finish_on_close=False):
+                self.submit()
+
+                # Cannot shutdown the executor and wait for the callbacks
+                # to be run, as in such case only the first will be executed,
+                # and the rest will get canceled.
+                await_until(lambda: len(self.tracer.finished_spans()) == 1, 5)
+
+        spans = self.tracer.finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].operation_name, 'one')
+
+        for i in range(1, 4):
+            self.assertEqual(spans[0].tags.get('key%s' % i, None), str(i))
+
+    def submit(self):
+        span = self.tracer.scope_manager.active.span
+
+        def task1():
+            with self.app.test_request_context():
+                with self.tracer.scope_manager.activate(span, False):
+                    span.set_tag('key1', '1')
+
+                    def task2():
+                        with self.app.test_request_context():
+                            with self.tracer.scope_manager.activate(span, False):
+                                span.set_tag('key2', '2')
+
+                                def task3():
+                                    with self.app.test_request_context():
+                                        with self.tracer.scope_manager.activate(span,
+                                                                                True):
+                                            span.set_tag('key3', '3')
+
+                                self.executor.submit(task3)
+
+                    self.executor.submit(task2)
+
+        self.executor.submit(task1)

--- a/testbed/test_subtask_span_propagation/test_flask.py
+++ b/testbed/test_subtask_span_propagation/test_flask.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, print_function
+
+from concurrent.futures import ThreadPoolExecutor
+from flask import Flask
+
+from opentracing.scope_managers.flask import FlaskScopeManager
+from opentracing.mocktracer import MockTracer
+from ..testcase import OpenTracingTestCase
+
+
+class TestFlask(OpenTracingTestCase):
+    def setUp(self):
+        self.tracer = MockTracer(FlaskScopeManager())
+        self.executor = ThreadPoolExecutor(max_workers=3)
+        self.app = Flask(__name__)
+
+    def test_main(self):
+        res = self.executor.submit(self.parent_task, 'message').result()
+        self.assertEqual(res, 'message::response')
+
+        spans = self.tracer.finished_spans()
+        self.assertEqual(len(spans), 2)
+        self.assertNamesEqual(spans, ['child', 'parent'])
+        self.assertIsChildOf(spans[0], spans[1])
+
+    def parent_task(self, message):
+        with self.app.test_request_context():
+            with self.tracer.start_active_span('parent') as scope:
+                f = self.executor.submit(self.child_task, message, scope.span)
+                res = f.result()
+
+        return res
+
+    def child_task(self, message, span):
+        with self.app.test_request_context():
+            with self.tracer.scope_manager.activate(span, False):
+                with self.tracer.start_active_span('child'):
+                    return '%s::response' % message

--- a/tests/scope_managers/test_flask.py
+++ b/tests/scope_managers/test_flask.py
@@ -1,0 +1,39 @@
+# Copyright (c) The OpenTracing Authors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+from unittest import TestCase
+
+from flask import Flask
+
+from opentracing.scope_managers.flask import FlaskScopeManager
+from opentracing.harness.scope_check import ScopeCompatibilityCheckMixin
+
+
+class FlaskCompabilityCheck(TestCase, ScopeCompatibilityCheckMixin):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def scope_manager(self):
+        return FlaskScopeManager()
+
+    def run_test(self, test_fn):
+        with self.app.test_request_context():
+            test_fn()


### PR DESCRIPTION
Adds a FlaskScopeManager using http://flask.pocoo.org/docs/1.0/api/?highlight=request_ctx_stack#flask._request_ctx_stack as currently done by https://github.com/opentracing-contrib/python-flask.