### PR TITLE
Add support for indicating if a global tracer has been registered

### DIFF
--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -34,6 +34,7 @@ from .propagation import UnsupportedFormatException  # noqa
 # 'from opentracing import tracer', the latter seems to take a copy.
 # DEPRECATED, use global_tracer() and set_global_tracer() instead.
 tracer = Tracer()
+is_registered = False
 
 
 def global_tracer():
@@ -58,3 +59,14 @@ def set_global_tracer(value):
 
     global tracer
     tracer = value
+
+    is_registered = True
+
+
+def is_global_tracer_registered():
+    """Indicates if a global tracer has been registered.
+
+    :rtype: :value:bool
+    :return: True if a global tracer has been registered, otherwise False.
+    """
+    return is_registered

--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -34,7 +34,7 @@ from .propagation import UnsupportedFormatException  # noqa
 # 'from opentracing import tracer', the latter seems to take a copy.
 # DEPRECATED, use global_tracer() and set_global_tracer() instead.
 tracer = Tracer()
-is_registered = False
+is_tracer_registered = False
 
 
 def global_tracer():
@@ -60,7 +60,8 @@ def set_global_tracer(value):
     global tracer
     tracer = value
 
-    is_registered = True
+    global is_tracer_registered
+    is_tracer_registered = True
 
 
 def is_global_tracer_registered():
@@ -69,4 +70,4 @@ def is_global_tracer_registered():
     :rtype: :value:bool
     :return: True if a global tracer has been registered, otherwise False.
     """
-    return is_registered
+    return is_tracer_registered

--- a/opentracing/__init__.py
+++ b/opentracing/__init__.py
@@ -57,10 +57,8 @@ def set_global_tracer(value):
     if value is None:
         raise ValueError('The global Tracer tracer cannot be None')
 
-    global tracer
+    global tracer, is_tracer_registered
     tracer = value
-
-    global is_tracer_registered
     is_tracer_registered = True
 
 
@@ -71,3 +69,11 @@ def is_global_tracer_registered():
     :return: True if a global tracer has been registered, otherwise False.
     """
     return is_tracer_registered
+
+
+def _reset_global_tracer():
+    """Reset any previously registered tracer. Intended for internal usage."""
+
+    global tracer, is_tracer_registered
+    tracer = Tracer()
+    is_tracer_registered = False

--- a/tests/test_globaltracer.py
+++ b/tests/test_globaltracer.py
@@ -36,3 +36,13 @@ def test_set_global_tracer(mock_obj):
 def test_register_none():
     with pytest.raises(ValueError):
         opentracing.set_global_tracer(None)
+
+
+def test_is_global_tracer_registered_defaults_to_false():
+    assert opentracing.is_global_tracer_registered() is False
+
+
+def test_is_global_tracer_registered_returns_true_after_registering_a_tracer():
+    tracer = mock.Mock()
+    opentracing.set_global_tracer(tracer)
+    assert opentracing.is_global_tracer_registered() is True

--- a/tests/test_globaltracer.py
+++ b/tests/test_globaltracer.py
@@ -18,31 +18,32 @@ import mock
 import opentracing
 
 
+def teardown_function(function):
+    opentracing._reset_global_tracer()
+
+
 def test_opentracing_tracer():
     assert opentracing.tracer is opentracing.global_tracer()
     assert isinstance(opentracing.global_tracer(), opentracing.Tracer)
 
 
-@mock.patch('opentracing.tracer')
-def test_set_global_tracer(mock_obj):
+def test_is_global_tracer_registered():
+    assert opentracing.is_global_tracer_registered() is False
+
+
+def test_set_global_tracer():
     tracer = mock.Mock()
     opentracing.set_global_tracer(tracer)
     assert opentracing.global_tracer() is tracer
+    assert opentracing.is_global_tracer_registered()
 
-    opentracing.set_global_tracer(mock_obj)
-    assert opentracing.global_tracer() is mock_obj
+    # Register another value.
+    tracer = mock.Mock()
+    opentracing.set_global_tracer(tracer)
+    assert opentracing.global_tracer() is tracer
+    assert opentracing.is_global_tracer_registered()
 
 
 def test_register_none():
     with pytest.raises(ValueError):
         opentracing.set_global_tracer(None)
-
-
-def test_is_global_tracer_registered_defaults_to_false():
-    assert opentracing.is_global_tracer_registered() is False
-
-
-def test_is_global_tracer_registered_returns_true_after_registering_a_tracer():
-    tracer = mock.Mock()
-    opentracing.set_global_tracer(tracer)
-    assert opentracing.is_global_tracer_registered() is True


### PR DESCRIPTION
Adds support for knowing if a global tracer has been registered via a global variable including tests.

NOTE: Python currently does not prevent you re-registering a global tracer multiple times like C# and Java does.