### PR TITLE
Use pytest-cov==2.6.0 as 2.6.1 depends on pytest>=3.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             'flake8-quotes',
             'mock<1.1.0',
             'pytest>=2.7,<3',
-            'pytest-cov',
+            'pytest-cov==2.6.0', # pytest-cov 2.6.1 depends on pytest>=3.6
             'pytest-mock',
             'Sphinx',
             'sphinx_rtd_theme',


### PR DESCRIPTION
Setting the `pytest-cov` to 2.6.0, as 2.6.1 changes its dependency from `pytest` 2.x to 3.x (!?).

This should get our builds back to green (recent ones such as #109 were failing because of this).

@yurishkuro @opentracing/opentracing-python-maintainers 