### PR TITLE
Fix __exit__ method of Scope class

### DIFF
--- a/opentracing/scope.py
+++ b/opentracing/scope.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 The OpenTracing Authors.
+# Copyright (c) 2017-2019 The OpenTracing Authors.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,6 +19,8 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
+
+from .span import Span
 
 
 class Scope(object):
@@ -78,5 +80,5 @@ class Scope(object):
         and added as a tag to the :class:`Span`.
         :attr:`~operation.ext.tags.ERROR` will also be set to `True`.
         """
-        self.span._on_error(exc_type, exc_val, exc_tb)
+        Span._on_error(self.span, exc_type, exc_val, exc_tb)
         self.close()

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -215,15 +215,16 @@ class Span(object):
         and added as a tag. :attr:`~operation.ext.tags.ERROR` will also be set
         to `True`.
         """
-        self._on_error(exc_type, exc_val, exc_tb)
+        Span._on_error(self, exc_type, exc_val, exc_tb)
         self.finish()
 
-    def _on_error(self, exc_type, exc_val, exc_tb):
-        if not exc_val:
+    @staticmethod
+    def _on_error(span, exc_type, exc_val, exc_tb):
+        if not span or not exc_val:
             return
 
-        self.set_tag(tags.ERROR, True)
-        self.log_kv({
+        span.set_tag(tags.ERROR, True)
+        span.log_kv({
             logs.EVENT: tags.ERROR,
             logs.MESSAGE: str(exc_val),
             logs.ERROR_OBJECT: exc_val,

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -74,3 +74,12 @@ def test_scope_error_report():
                               ValueError)
             assert isinstance(log_kv_args.get(logs.STACK, None),
                               types.TracebackType)
+
+
+def test_scope_exit_with_no_span():
+    # ensure `Scope.__exit__` doesn't fail with `AttributeError`
+    try:
+        with Scope(None, None):
+            raise ValueError
+    except ValueError:
+        pass


### PR DESCRIPTION
Hello,

Technically, a scope could contain `None` as a span, but on exit it calls `_on_error` on a span with no check.

Currently, this issue affects `opentracing_instrumentation` library:
https://travis-ci.org/uber-common/opentracing-python-instrumentation/jobs/525712144#L530-L616

These changes:
 - Make the `_on_error` method static
 - Add a check for a span to the `_on_error` method

cc @carlosalberto

~**Note:** Error for Python 3.6 on CI was expected and it's not related to these changes.~