### PR TITLE
Add support for Python 3.5/3.7 and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
+dist: xenial
+
 language: python
 python:
   - "2.7"
+  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8-dev"
+
+matrix:
+  allow_failures:
+    - python: "3.8-dev"
 
 install:
   - make bootstrap
 
 script:
   - make test testbed lint
-

--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ There exist implementations for ``thread-local`` (the default instance of the su
 .. code-block:: python
 
    from opentracing.scope_managers.gevent import GeventScopeManager # requires gevent
-   from opentracing.scope_managers.tornado import TornadoScopeManager # requires Tornado
+   from opentracing.scope_managers.tornado import TornadoScopeManager # requires tornado<6
    from opentracing.scope_managers.asyncio import AsyncioScopeManager # requires Python 3.4 or newer.
 
 Development
@@ -221,6 +221,12 @@ Tests
    . ./env/bin/activate
    make bootstrap
    make test
+
+You can use `tox <https://tox.readthedocs.io>`_ to run tests as well.
+
+.. code-block:: sh
+
+    tox
 
 Testbed suite
 ^^^^^^^^^^^^^

--- a/opentracing/propagation.py
+++ b/opentracing/propagation.py
@@ -63,8 +63,8 @@ class Format(object):
 
     TEXT_MAP = 'text_map'
     """
-    The TEXT_MAP format represents :class:`SpanContext`\ s in a python ``dict``
-    mapping from strings to strings.
+    The TEXT_MAP format represents :class:`SpanContext`\\ s in a python
+    ``dict`` mapping from strings to strings.
 
     Both the keys and the values have unrestricted character sets (unlike the
     HTTP_HEADERS format).
@@ -77,7 +77,7 @@ class Format(object):
 
     HTTP_HEADERS = 'http_headers'
     """
-    The HTTP_HEADERS format represents :class:`SpanContext`\ s in a python
+    The HTTP_HEADERS format represents :class:`SpanContext`\\ s in a python
     ``dict`` mapping from character-restricted strings to strings.
 
     Keys and values in the HTTP_HEADERS carrier must be suitable for use as

--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -21,7 +21,7 @@ from opentracing.ext import tags
 
 class SpanContext(object):
     """SpanContext represents :class:`Span` state that must propagate to
-    descendant :class:`Span`\ s and across process boundaries.
+    descendant :class:`Span`\\ s and across process boundaries.
 
     SpanContext is logically divided into two pieces: the user-level "Baggage"
     (see :meth:`Span.set_baggage_item` and :meth:`Span.get_baggage_item`) that

--- a/opentracing/tracer.py
+++ b/opentracing/tracer.py
@@ -98,7 +98,7 @@ class Tracer(object):
         :type child_of: Span or SpanContext
 
         :param references: (optional) references that identify one or more
-            parent :class:`SpanContext`\ s. (See the Reference documentation
+            parent :class:`SpanContext`\\ s. (See the Reference documentation
             for detail).
         :type references: :obj:`list` of :class:`Reference`
 
@@ -165,7 +165,7 @@ class Tracer(object):
         :type child_of: Span or SpanContext
 
         :param references: (optional) references that identify one or more
-            parent :class:`SpanContext`\ s. (See the Reference documentation
+            parent :class:`SpanContext`\\ s. (See the Reference documentation
             for detail).
         :type references: :obj:`list` of :class:`Reference`
 
@@ -256,7 +256,7 @@ class Reference(namedtuple('Reference', ['type', 'referenced_context'])):
     """A Reference pairs a reference type with a referenced :class:`SpanContext`.
 
     References are used by :meth:`Tracer.start_span()` to describe the
-    relationships between :class:`Span`\ s.
+    relationships between :class:`Span`\\ s.
 
     :class:`Tracer` implementations must ignore references where
     referenced_context is ``None``.  This behavior allows for simpler code when
@@ -321,7 +321,7 @@ def start_child_span(parent_span, operation_name, tags=None, start_time=None):
             start_time=start_time)
 
     :param parent_span: the :class:`Span` which will act as the parent in the
-        returned :class:`Span`\ s child_of reference.
+        returned :class:`Span`\\ s child_of reference.
     :type parent_span: Span
 
     :param operation_name: the operation name for the child :class:`Span`

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
@@ -27,18 +29,18 @@ setup(
     extras_require={
         'tests': [
             'doubles',
-            'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
+            'flake8',
             'flake8-quotes',
-            'mock<1.1.0',
-            'pytest>=2.7,<3',
-            'pytest-cov==2.6.0', # pytest-cov 2.6.1 depends on pytest>=3.6
+            'mock',
+            'pytest',
+            'pytest-cov',
             'pytest-mock',
             'Sphinx',
             'sphinx_rtd_theme',
 
             'six>=1.10.0,<2.0',
-            'gevent==1.2',
-            'tornado',
+            'gevent',
+            'tornado<6',
         ],
         ':python_version == "2.7"': ['futures'],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py35,py36,py37
+
+[testenv]
+install_command = pip install {opts} {packages} {env:PWD}[tests]
+whitelist_externals = make
+commands =  make test testbed lint


### PR DESCRIPTION
Hello,

As a software engineer, I'd like to have support for modern versions of Python declared in `setup.py` and to have corresponding tests on CI.

Also, I'd like to be able to conveniently run tests in my local environment, so I want to add a `tox` config file.

These changes:
 - Add Python 3.5 and 3.7 to `setup.py`
 - Add Python 3.5, 3.7, and 3.8-dev to `.travis.yml`
 - Add `tox.ini`
 - Add a mention of `tox` into `Development` section of `README`
 - Pin `tornado` at the tests requriements to `<6`
 - Simplify the tests requirements
 - Fix `flake8` warnings (for the latest version of `flake8`)