### PR TITLE
Make logs.STACK use a stringified traceback.

### DIFF
--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -16,6 +16,8 @@
 from __future__ import absolute_import
 from . import logs
 
+import traceback
+
 from opentracing.ext import tags
 
 
@@ -229,7 +231,7 @@ class Span(object):
             logs.MESSAGE: str(exc_val),
             logs.ERROR_OBJECT: exc_val,
             logs.ERROR_KIND: exc_type,
-            logs.STACK: exc_tb,
+            logs.STACK: ''.join(traceback.format_tb(exc_tb)),
         })
 
     def log_event(self, event, payload=None):

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import
 import mock
 import time
-import types
 from opentracing import child_of
 from opentracing import Format
 from opentracing import Tracer
@@ -85,8 +84,8 @@ def test_span_error_report():
             assert log_kv_args.get(logs.ERROR_KIND, None) is ValueError
             assert isinstance(log_kv_args.get(logs.ERROR_OBJECT, None),
                               ValueError)
-            assert isinstance(log_kv_args.get(logs.STACK, None),
-                              types.TracebackType)
+            assert isinstance(log_kv_args.get(logs.STACK, None), str)
+            assert 'raise ValueError' in log_kv_args.get(logs.STACK)
 
 
 def test_inject():

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 
 import mock
-import types
 
 from opentracing.scope_manager import ScopeManager
 from opentracing.tracer import Tracer
@@ -72,8 +71,8 @@ def test_scope_error_report():
             assert log_kv_args.get(logs.ERROR_KIND, None) is ValueError
             assert isinstance(log_kv_args.get(logs.ERROR_OBJECT, None),
                               ValueError)
-            assert isinstance(log_kv_args.get(logs.STACK, None),
-                              types.TracebackType)
+            assert isinstance(log_kv_args.get(logs.STACK, None), str)
+            assert 'raise ValueError' in log_kv_args.get(logs.STACK)
 
 
 def test_scope_exit_with_no_span():


### PR DESCRIPTION
According to the specification, when using `logs.STACK` to attach the traceback, we should be using a string version of it, not the actual object (as opposed to `logs.ERROR_OBJECT`).

My only question is whether this could break compatibility, in case somebody out there was already using `logs.STACK` as the tb itself - then again, we should stick to the specification.

@yurishkuro opinion on this?