### PR TITLE
Add ability to specify parent span in tracer_span_context in TornadoScopeManager

### DIFF
--- a/testbed/test_multiple_callbacks/test_tornado.py
+++ b/testbed/test_multiple_callbacks/test_tornado.py
@@ -63,3 +63,96 @@ class TestTornado(OpenTracingTestCase):
             tasks.append(t)
 
         return tasks
+
+    def test_multiple_callbacks_scheduled_in_loop(self):
+        """
+        This test emulates concurrent execution of two scheduled callbacks.
+        One callback has yield operation that switching context of execution to
+        another one callback.
+        When execution of first callback resumes back, it's active scope must
+        be the same.
+        """
+
+        @gen.coroutine
+        def callback_1(name):
+            with self.tracer.start_active_span(name) as scope:
+                yield gen.sleep(0.1)
+                # Check that another concurrently executed callback doesn't
+                # change original scope.
+                self.assertEqual(self.tracer.scope_manager.active, scope)
+                self.assertEqual(self.tracer.active_span, scope.span)
+
+        def callback_2(name):
+            with self.tracer.start_active_span(name):
+                pass
+
+        @gen.coroutine
+        def main_task():
+            with self.tracer.start_active_span('parent') as scope:
+                # Each callback should be wrapped by their own stack context.
+                with tracer_stack_context(scope.span):
+                    self.loop.add_callback(callback_1, 'foo')
+                with tracer_stack_context(scope.span):
+                    self.loop.add_callback(callback_2, 'bar')
+
+        with tracer_stack_context():
+            self.loop.add_callback(main_task)
+
+        stop_loop_when(self.loop,
+                       lambda: len(self.tracer.finished_spans()) == 3)
+        self.loop.start()
+
+        parent, bar, foo = self.tracer.finished_spans()
+        # Callbacks will be finished later than their parent.
+        self.assertNamesEqual([parent, bar, foo], ['parent', 'bar', 'foo', ])
+
+        self.assertSameTrace(parent, bar)
+        self.assertSameTrace(parent, foo)
+
+        self.assertIsChildOf(foo, parent)
+        self.assertIsChildOf(bar, parent)
+
+    def test_concurrent_fire_and_forget_coroutines(self):
+        """
+        This test emulates concurrent execution of fire & forget coroutines.
+        Each coroutine has two yield operation that switching context of
+        execution to another one coroutine.
+        When execution of a coroutine resumes back, it's active scope must be
+        the same.
+        """
+
+        @gen.coroutine
+        def coro(name):
+            with self.tracer.start_active_span(name) as scope:
+                yield gen.sleep(0.1)
+                # Check that another concurrently executed coroutine doesn't
+                # change original scope.
+                self.assertEqual(self.tracer.scope_manager.active, scope)
+                self.assertEqual(self.tracer.active_span, scope.span)
+                yield gen.sleep(0.1)
+
+        @gen.coroutine
+        def main_task():
+            with self.tracer.start_active_span('parent') as scope:
+                # Each coroutine should be wrapped by their own stack context.
+                with tracer_stack_context(scope.span):
+                    coro('foo')
+                with tracer_stack_context(scope.span):
+                    coro('bar')
+
+        with tracer_stack_context():
+            main_task()
+
+        stop_loop_when(self.loop,
+                       lambda: len(self.tracer.finished_spans()) == 3)
+        self.loop.start()
+
+        parent, foo, bar = self.tracer.finished_spans()
+        # Coroutines will be finished later than their parent.
+        self.assertNamesEqual([parent, foo, bar], ['parent', 'foo', 'bar', ])
+
+        self.assertSameTrace(parent, foo)
+        self.assertSameTrace(parent, bar)
+
+        self.assertIsChildOf(foo, parent)
+        self.assertIsChildOf(bar, parent)

--- a/testbed/test_subtask_span_propagation/test_tornado.py
+++ b/testbed/test_subtask_span_propagation/test_tornado.py
@@ -8,6 +8,7 @@ from opentracing.mocktracer import MockTracer
 from opentracing.scope_managers.tornado import TornadoScopeManager, \
         tracer_stack_context
 from ..testcase import OpenTracingTestCase
+from ..utils import stop_loop_when
 
 
 class TestTornado(OpenTracingTestCase):
@@ -16,7 +17,22 @@ class TestTornado(OpenTracingTestCase):
         self.loop = ioloop.IOLoop.current()
 
     def test_main(self):
-        parent_task = functools.partial(self.parent_task, 'message')
+
+        @gen.coroutine
+        def child_task(message):
+            # No need to pass/activate the parent Span, as
+            # it stays in the context.
+            with self.tracer.start_active_span('child'):
+                raise gen.Return('%s::response' % message)
+
+        @gen.coroutine
+        def parent_task(message):
+            with self.tracer.start_active_span('parent'):
+                res = yield child_task(message)
+
+            raise gen.Return(res)
+
+        parent_task = functools.partial(parent_task, 'message')
         with tracer_stack_context():
             res = self.loop.run_sync(parent_task)
         self.assertEqual(res, 'message::response')
@@ -26,16 +42,77 @@ class TestTornado(OpenTracingTestCase):
         self.assertNamesEqual(spans, ['child', 'parent'])
         self.assertIsChildOf(spans[0], spans[1])
 
-    @gen.coroutine
-    def parent_task(self, message):
-        with self.tracer.start_active_span('parent'):
-            res = yield self.child_task(message)
+    def test_callbacks(self):
 
-        raise gen.Return(res)
+        def child_callback_2():
+            with self.tracer.start_active_span('child_2'):
+                pass
 
-    @gen.coroutine
-    def child_task(self, message):
-        # No need to pass/activate the parent Span, as
-        # it stays in the context.
-        with self.tracer.start_active_span('child'):
-            raise gen.Return('%s::response' % message)
+        def child_callback_1():
+            with self.tracer.start_active_span('child_1') as scope:
+                # Should be wrapped by `tracer_stack_context` to store right
+                # context in scheduled callback.
+                with tracer_stack_context(scope.span):
+                    self.loop.add_callback(child_callback_2)
+
+        def parent_callback():
+            with self.tracer.start_active_span('parent') as scope:
+                with tracer_stack_context(scope.span):
+                    self.loop.add_callback(child_callback_1)
+
+        with tracer_stack_context():
+            self.loop.add_callback(parent_callback)
+
+        stop_loop_when(self.loop,
+                       lambda: len(self.tracer.finished_spans()) == 3)
+        self.loop.start()
+
+        # Callback will be finished later than their parent.
+        parent, child_1, child_2 = self.tracer.finished_spans()
+        self.assertNamesEqual(
+            [parent, child_1, child_2], ['parent', 'child_1', 'child_2'])
+        self.assertSameTrace(child_1, parent)
+        self.assertSameTrace(child_2, parent)
+
+        self.assertIsChildOf(child_1, parent)
+        self.assertIsChildOf(child_2, child_1)
+
+    def test_fire_and_forget_coroutines(self):
+
+        @gen.coroutine
+        def child_coro_2():
+            yield gen.sleep(0.1)
+            with self.tracer.start_active_span('child_2'):
+                pass
+
+        @gen.coroutine
+        def child_coro_1():
+            with self.tracer.start_active_span('child_1') as scope:
+                # Should be wrapped by `tracer_stack_context` to store right
+                # context in scheduled callback.
+                yield gen.sleep(0.1)
+                with tracer_stack_context(scope.span):
+                    child_coro_2()
+
+        @gen.coroutine
+        def parent_coro():
+            with self.tracer.start_active_span('parent') as scope:
+                with tracer_stack_context(scope.span):
+                    child_coro_1()
+
+        with tracer_stack_context():
+            parent_coro()
+
+        stop_loop_when(self.loop,
+                       lambda: len(self.tracer.finished_spans()) == 3)
+        self.loop.start()
+
+        # Callback will be finished later than their parent.
+        parent, child_1, child_2 = self.tracer.finished_spans()
+        self.assertNamesEqual(
+            [parent, child_1, child_2], ['parent', 'child_1', 'child_2'])
+        self.assertSameTrace(child_1, parent)
+        self.assertSameTrace(child_2, parent)
+
+        self.assertIsChildOf(child_1, parent)
+        self.assertIsChildOf(child_2, child_1)


### PR DESCRIPTION
Some time ago I faced with problem of tracing fire & forget coroutines in Tornado.
As documentation says, we must run such coroutines in `tracer_stack_context` to prevent breaking of original scope:
```
@gen.coroutine
def coro():
    with global_tracer().start_active_span('background_task'):
        # do something in backgound

with tracer_stack_context():
    coro()
```

Based on tornado's `StackContext`, that actually proto-contextvars, `tracer_stack_context` make new isolated scope for coroutines and this mechanism works well.

But `tracer_stack_context` doesn't provide a way to setup active span in this new scope. If you want to make span propagation for fire & forget coroutines, you have to pass and activate your (current) span explicitly in the couroutine. It can be difficult and complicates code instrumentation.
For example, my first (and ugly) iteration of wrapper for fire & forget coroutines that we successfully use in one of our microservice https://github.com/condorcet/tornado-coroutines-opentracing/blob/master/tornado_coroutines_opentracing/__init__.py#L15

The same problem with scheduling callbacks/futures in event loop -- there is no easy way to make auto-propagation of current span to them.

In the PR `tracer_stack_context` has new optional argument `parent_span` that specify span that will be used in new scope prepared by stack context.
I think it can make auto-propagation easier for Tornado applications.
For example my second iteration of wrapper based on it: https://github.com/condorcet/tornado-coroutines-opentracing/blob/072a9d65f0e49eaf63fb3aff93b1090f06a4a7b3/tornado_coroutines_opentracing/__init__.py#L33