### PR TITLE
Move from asyncio.Task.current_task() to asyncio.current_task()

### DIFF
--- a/opentracing/scope_managers/asyncio.py
+++ b/opentracing/scope_managers/asyncio.py
@@ -31,7 +31,7 @@ class AsyncioScopeManager(ThreadLocalScopeManager):
     """
     :class:`~opentracing.ScopeManager` implementation for **asyncio**
     that stores the :class:`~opentracing.Scope` in the current
-    :class:`Task` (:meth:`Task.current_task()`), falling back to
+    :class:`Task` (:meth:`asyncio.current_task()`), falling back to
     thread-local storage if none was being executed.
 
     Automatic :class:`~opentracing.Span` propagation from
@@ -107,7 +107,7 @@ class AsyncioScopeManager(ThreadLocalScopeManager):
         except RuntimeError:
             return None
 
-        return asyncio.Task.current_task(loop=loop)
+        return asyncio.current_task(loop=loop)
 
     def _set_task_scope(self, scope, task=None):
         if task is None:


### PR DESCRIPTION
asyncio.Task.current_task() is deprecated, and generates lots of warnings in the pytests.

```
$ python3.7 -m pytest tests
[...]
platform linux -- Python 3.7.5rc1, pytest-3.10.1, py-1.8.0, pluggy-0.12.0
[...]
tests/scope_managers/test_asyncio.py::AsyncioCompabilityCheck::test_activate
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
  /home/noon/git/opentracing-python/opentracing/scope_managers/asyncio.py:110: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead
    return asyncio.Task.current_task(loop=loop)
[...]
```