### PR TITLE
Report error= tag according to spec

### DIFF
--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -223,7 +223,7 @@ class Span(object):
         if not span or not exc_val:
             return
 
-        span.set_tag(tags.ERROR, True)
+        span.set_tag(tags.ERROR, 'true')
         span.log_kv({
             logs.EVENT: tags.ERROR,
             logs.MESSAGE: str(exc_val),

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -76,7 +76,7 @@ def test_span_error_report():
                 pass
 
             assert set_tag.call_count == 1
-            assert set_tag.call_args[0] == (tags.ERROR, True)
+            assert set_tag.call_args[0] == (tags.ERROR, 'true')
 
             assert log_kv.call_count == 1
             log_kv_args = log_kv.call_args[0][0]

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -63,7 +63,7 @@ def test_scope_error_report():
                 pass
 
             assert set_tag.call_count == 1
-            assert set_tag.call_args[0] == (tags.ERROR, True)
+            assert set_tag.call_args[0] == (tags.ERROR, 'true')
 
             assert log_kv.call_count == 1
             log_kv_args = log_kv.call_args[0][0]


### PR DESCRIPTION
With this change in place, we now report `error=true` (note lower case `t`) as described [in the spec](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table), when something fails inside of a span.

Before this change, errors were reported with a capital `T`.

Then, when using the Lightstep web UI to search for `error=true`, you wouldn't find any Python failures.

To find the Python errors, you had to search for `error=True`, which was (undocumented and) not obvious.