### PR TITLE
Adding on span error callbacks

### DIFF
--- a/opentracing/span.py
+++ b/opentracing/span.py
@@ -18,6 +18,14 @@ from . import logs
 
 from opentracing.ext import tags
 
+on_error_callbacks = []
+
+
+def add_on_error_callback(fn):
+    global on_error_callbacks
+
+    on_error_callbacks.append(fn)
+
 
 class SpanContext(object):
     """SpanContext represents :class:`Span` state that must propagate to
@@ -222,6 +230,9 @@ class Span(object):
     def _on_error(span, exc_type, exc_val, exc_tb):
         if not span or not exc_val:
             return
+
+        for callback in on_error_callbacks:
+            callback(span, exc_type, exc_val, exc_tb)
 
         span.set_tag(tags.ERROR, True)
         span.log_kv({


### PR DESCRIPTION
I'd like to extend the functionality of Span._on_error to allow
integrating other tools with the error handling of the spans.

I don't think monkey patching is the good way to go on this, since also
`Span._on_error` is a private method.

Another approach would be having a `exit_callbacks` list to be executed
on each `__exit__` call.

I am not sure this funcionality exists on other languages implementation
but it'd open the door to do more powerful integrtions with OpenTracing.