### PR TITLE
[asyncio] Fix get current task on Python 3.9

### DIFF
--- a/opentracing/scope_managers/asyncio.py
+++ b/opentracing/scope_managers/asyncio.py
@@ -107,7 +107,7 @@ class AsyncioScopeManager(ThreadLocalScopeManager):
         except RuntimeError:
             return None
 
-        return asyncio.Task.current_task(loop=loop)
+        return asyncio.current_task(loop=loop)
 
     def _set_task_scope(self, scope, task=None):
         if task is None:


### PR DESCRIPTION
Python 3.9 has removed `asyncio.Task.current_task`, from the docs:

> The asyncio.Task.current_task() and asyncio.Task.all_tasks() have been removed. They were deprecated since Python 3.7 and you can use asyncio.current_task() and asyncio.all_tasks() instead. (Contributed by Rémi Lapeyre in bpo-40967)

https://docs.python.org/3.9/whatsnew/3.9.html?highlight=current_task