### PR TITLE
Fix typo in README.rst: opentracing.ScopeManager.active is a property not a method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ another task or thread, but not ``Scope``.
 .. code-block:: python
 
        # Access to the active span is straightforward.
-       scope = tracer.scope_manager.active()
+       scope = tracer.scope_manager.active
        if scope is not None:
            scope.span.set_tag('...', '...')
 


### PR DESCRIPTION
`opentracing.ScopeManager.active` is a property, therefore, we should not add brackets when it is accessed