### PR TITLE
Do not use mock (the PyPI backport library) when possible

### DIFF
--- a/opentracing/harness/api_check.py
+++ b/opentracing/harness/api_check.py
@@ -14,7 +14,11 @@
 
 from __future__ import absolute_import
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import time
 import pytest
 

--- a/opentracing/harness/scope_check.py
+++ b/opentracing/harness/scope_check.py
@@ -19,7 +19,10 @@
 # THE SOFTWARE.
 from __future__ import absolute_import
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opentracing.span import Span
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'tests': [
             'flake8',
             'flake8-quotes',
-            'mock',
+            'mock;python_version<"3.3"',
             'pytest',
             'pytest-cov',
             'pytest-mock',

--- a/tests/test_globaltracer.py
+++ b/tests/test_globaltracer.py
@@ -14,8 +14,11 @@
 
 from __future__ import absolute_import
 import pytest
-import mock
 import opentracing
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 def teardown_function(function):

--- a/tests/test_noop_span.py
+++ b/tests/test_noop_span.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import mock
 import time
 import types
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from opentracing import child_of
 from opentracing import Format
 from opentracing import Tracer

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -20,8 +20,11 @@
 
 from __future__ import absolute_import
 
-import mock
 import types
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from opentracing.scope_manager import ScopeManager
 from opentracing.tracer import Tracer


### PR DESCRIPTION
This is an attempt to fix #142.