### PR TITLE
Replace @asyncio.coroutine with “async def” for Python 3.11

### DIFF
--- a/tests/scope_managers/test_asyncio.py
+++ b/tests/scope_managers/test_asyncio.py
@@ -35,8 +35,7 @@ class AsyncioCompabilityCheck(TestCase, ScopeCompatibilityCheckMixin):
         return AsyncioScopeManager()
 
     def run_test(self, test_fn):
-        @asyncio.coroutine
-        def async_test_fn():
+        async def async_test_fn():
             test_fn()
         asyncio.get_event_loop().run_until_complete(async_test_fn())
 

--- a/tests/scope_managers/test_contextvars.py
+++ b/tests/scope_managers/test_contextvars.py
@@ -36,8 +36,7 @@ class AsyncioContextVarsCompabilityCheck(
         return ContextVarsScopeManager()
 
     def run_test(self, test_fn):
-        @asyncio.coroutine
-        def async_test_fn():
+        async def async_test_fn():
             test_fn()
         asyncio.get_event_loop().run_until_complete(async_test_fn())
 


### PR DESCRIPTION
In the tests, replace the [asyncio.coroutine decorator](https://docs.python.org/3/library/asyncio-task.html#asyncio.coroutine), which is deprecated since Python 3.8 and removed in 3.11, with “`async def`”.

Because async functionality was not available in Python 2.7, and `async def` was introduced in 3.5, this does not appear to break the tests, except that `flake8` in the Python 2.7 `tox` environment chokes on a `SyntaxError` for the two test files that are modified in this PR. I’m not sure what you would prefer to do about that.