### PR TITLE
docs: fix simple typo, corotuines -> coroutines

### DIFF
--- a/opentracing/scope_managers/tornado.py
+++ b/opentracing/scope_managers/tornado.py
@@ -95,7 +95,7 @@ class TornadoScopeManager(ThreadLocalScopeManager):
         If no :func:`tracer_stack_context()` is detected, thread-local
         storage will be used to store the :class:`~opentracing.Scope`.
         Observe that in this case the active :class:`~opentracing.Span`
-        will not be automatically propagated to the child corotuines.
+        will not be automatically propagated to the child coroutines.
 
         :return: a :class:`~opentracing.Scope` instance to control the end
             of the active period for the :class:`~opentracing.Span`.


### PR DESCRIPTION
There is a small typo in opentracing/scope_managers/tornado.py.

Should read `coroutines` rather than `corotuines`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md